### PR TITLE
Add step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>sezpoz</artifactId>
       <version>1.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.5.0<</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.5.0<</version>
+      <version>2.5.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/MockExtensionLists.java
+++ b/src/main/java/hudson/MockExtensionLists.java
@@ -1,0 +1,55 @@
+/**
+ * This mocks a few different
+ */
+
+package hudson;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import org.jenkinsci.pipeline_steps_doc_generator.HyperLocalPluginManger;
+
+import static org.mockito.Mockito.*;
+import org.mockito.stubbing.Answer;
+import org.mockito.invocation.InvocationOnMock;
+import hudson.ExtensionList;
+import hudson.model.Hudson;
+import jenkins.model.Jenkins;
+
+public class MockExtensionLists {
+    private static Map<String, ExtensionList> extensionLists = new HashMap<String, ExtensionList>();    
+
+    public ExtensionList getMockExtensionList(HyperLocalPluginManger hlpm, Jenkins hudson, Class type) {
+        if(extensionLists.get(type.getName()) != null) {
+            return extensionLists.get(type.getName());
+        } else {
+            MockExtensionList mockList = new MockExtensionList(hlpm, hudson, type);
+            extensionLists.put(type.getName(), mockList.getMockExtensionList());
+            return mockList.getMockExtensionList();
+        }
+    }
+
+    private class MockExtensionList {
+        ExtensionList mockExtensionList;
+
+        public MockExtensionList(HyperLocalPluginManger hlpm, Jenkins hudson, Class type) {
+            ExtensionList realList = ExtensionList.create(hudson, type);
+            mockExtensionList = spy(realList);
+
+            doReturn("Locking resources").when(mockExtensionList).getLoadLock();
+            doAnswer(mockLoad(hlpm)).when(mockExtensionList).load();
+        }
+
+        private <T> Answer<List<ExtensionComponent<T>>> mockLoad(HyperLocalPluginManger hlpm) {
+            return new Answer<List<ExtensionComponent<T>>>() {
+                public List<ExtensionComponent<T>> answer(InvocationOnMock invocation) throws Throwable {
+                    return hlpm.getPluginStrategy().findComponents(mockExtensionList.extensionType, (Hudson)null);
+                }
+            };
+        }
+
+        public ExtensionList getMockExtensionList(){
+            return mockExtensionList;
+        }
+    }
+}

--- a/src/main/java/hudson/MockJenkins.java
+++ b/src/main/java/hudson/MockJenkins.java
@@ -1,0 +1,44 @@
+/**
+ * Mock for the Jenkins/Hudson object required for processing
+ * the various steps.  This became very important after introducing
+ * mocking as pretty much every class wants to know what's happening
+ * within Jenkins.  Nothing here actually starts the process, and
+ * provides a very bland "Jenkins" startup
+ *
+ * This mock technically should be for Jenkins.class.  However, 
+ * ExtensionList pretty much requires that the object also be of 
+ * type Hudson.  Since Mockito works by creating a subclass of the 
+ * desired class, it has to be of Hudson.  This should be changed 
+ * when ExtensionList no longer requires a Hudon object.
+ */
+ package hudson;
+
+import hudson.ExtensionList;
+import hudson.init.InitMilestone;
+import hudson.model.Hudson; //only needed until Hudson reference is removed from the ExtensionList.
+import jenkins.model.Jenkins;
+import org.jenkinsci.pipeline_steps_doc_generator.HyperLocalPluginManger;
+
+import static org.mockito.Mockito.*;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+ public class MockJenkins {
+     private MockExtensionLists mockLookup = new MockExtensionLists();
+
+     public Jenkins getMockJenkins(HyperLocalPluginManger pm) {
+         Jenkins mockJenkins = mock(Hudson.class); //required by ExtensionList
+         when(mockJenkins.getPluginManager()).thenReturn(pm);
+         when(mockJenkins.getInitLevel()).thenReturn(InitMilestone.COMPLETED);
+
+         doAnswer(new Answer<ExtensionList>() {
+            @Override
+            public ExtensionList answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                return mockLookup.getMockExtensionList(pm, mockJenkins, (Class) args[0]);
+            }
+         }).when(mockJenkins).getExtensionList(any(Class.class));
+
+         return mockJenkins;
+     }
+ }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -65,7 +65,7 @@ public class ToAsciiDoc {
           .replaceAll("</?pre>", "\n----\n")
           .replaceAll("</?div>", "")
           .replaceAll("</?p>", "\n\n");
-
+        
         return tagged.replaceAll("<(.|\n)*?>", "").trim();
     }
 
@@ -97,7 +97,7 @@ public class ToAsciiDoc {
             }
         } else if (type instanceof ErrorType) { //Shouldn't hit this; open a ticket
             Exception x = ((ErrorType) type).getError();
-            if(x instanceof NoStaplerConstructorException) {
+            if(x instanceof NoStaplerConstructorException || x instanceof UnsupportedOperationException) {
                 String msg = x.toString();
                 typeInfo.append("+").append(msg.substring(msg.lastIndexOf(" "))).append("+\n");
             } else {
@@ -125,8 +125,8 @@ public class ToAsciiDoc {
             return "";  // if we are recursing, cut the search
         nesting.push(model.getType());
 
+        StringBuilder total = new StringBuilder();
         try {
-            StringBuilder total = new StringBuilder();
             String help = model.getHelp();
             if (help != null && !help.equals("")) {
                 total.append(helpify(help));
@@ -134,9 +134,9 @@ public class ToAsciiDoc {
 
             StringBuilder optionalParams = new StringBuilder();
             //for(DescribableParameter p : model.getParameters()){
-            for(Object o : model.getParameters()){
+            for(Object o : model.getParameters()) {
                 DescribableParameter p = (DescribableParameter) o;
-                if(p.isRequired()){
+                if(p.isRequired()) {
                     total.append("+").append(p.getName()).append("+").append(listDepth(headerLevel)).append("\n+\n");
                     total.append(generateAttrHelp(p, headerLevel));
                     total.append("\n\n");
@@ -147,10 +147,9 @@ public class ToAsciiDoc {
                 }
             }
             total.append(optionalParams.toString());
-
-            return total.toString();
         } finally {
             nesting.pop();
+            return total.toString();
         }
     }
 
@@ -169,7 +168,7 @@ public class ToAsciiDoc {
         }
         return mkDesc.toString();
     }
-
+    
     /**
      * Creates a header for use in JenkinsIO and other awestruct applications.
      */
@@ -178,11 +177,11 @@ public class ToAsciiDoc {
         head.append(pluginName)
           .append("\"\n---\n:doctitle: ")
           .append(pluginName)
-          .append("\n:notitle:\n:description:\n:author:\n:email: jenkinsci-users@googlegroups.com\n:sectanchors:\n:toc: left\n\n");
+		  .append("\n:notitle:\n:description:\n:author:\n:email: jenkinsci-users@googlegroups.com\n:sectanchors:\n:toc: left\n\n");
 
         return head.toString();
     }
-
+    
     /**
      * Generate help documentation for an entire plugin.  Returns a String that can
      * be saved into a file.
@@ -197,7 +196,7 @@ public class ToAsciiDoc {
         if(genHeader){
             whole9yards.append(generateHeader(pluginName));
         }
-
+        
         whole9yards.append("== ").append(pluginName).append("\n\n");
         for(String type : byPlugin.keySet()){
             for(StepDescriptor sd : byPlugin.get(type)){


### PR DESCRIPTION
findSubtypes uses ExtensionLists to determine derived classes.  This is critcial to any operation that uses anything other than Java classes as the required object type.  Also some required classes were not
loading/failing right away due to missing Jenkins.  The sort of convoluted way to fix this was to introduce mocking.  Now, there's a Jenkins "object" that is barebones enough to handle the necessary methods to load the missing steps.

Up for review, esp @rtyler 