### PR TITLE
Switch to 'pipelinesteps' layout

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -150,7 +150,7 @@ public class ToAsciiDoc {
      * Creates a header for use in JenkinsIO and other awestruct applications.
      */
     private static String generateHeader(String pluginName){
-        StringBuilder head = new StringBuilder("---\nlayout: simplepage\nnotitle: true\ntitle: \"");
+        StringBuilder head = new StringBuilder("---\nlayout: pipelinesteps\ntitle: \"");
         head.append(pluginName)
           .append("\"\n---\n")
 		  .append("\n:notitle:\n:description:\n:author:\n:email: jenkinsci-users@googlegroups.com\n:sectanchors:\n:toc: left\n\n");


### PR DESCRIPTION
For now, the major feature of this layout is that pages appear uneditable (no links to GitHub in the footer):
https://github.com/jenkins-infra/jenkins.io/blob/master/content/_layouts/pipelinesteps.html.haml

Other than that, this allows to more flexibly affect the presentation of these doc pages via jenkins-infra/jenkins.io.

CC @rtyler 