### PR TITLE
[INFRA-1053] Generate Declarative directive docs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,8 @@ node('linux') {
         timestamps {
             dir('docFolder') {
                 zip dir: './allAscii', glob: '', zipFile: 'allAscii.zip'
-                archiveArtifacts artifacts: 'allAscii.zip', fingerprint: true
+                zip dir: './declarative', glob: '', zipFile: 'declarative.zip'
+                archiveArtifacts artifacts: 'allAscii.zip,declarative.zip', fingerprint: true
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
-      <version>1.2.5-20171116.195307-2</version> <!-- Switch to release once https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/219 is merged and released -->
+      <version>1.2.4</version>
     </dependency>
     <dependency>
       <groupId>net.java.sezpoz</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-      <version>1.651</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -76,7 +76,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.5</version>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-extensions</artifactId>
+      <version>1.2.5-20171116.195307-2</version> <!-- Switch to release once https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/219 is merged and released -->
     </dependency>
     <dependency>
       <groupId>net.java.sezpoz</groupId>

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -237,9 +237,12 @@ public class PipelineStepExtractor {
         Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = getDeclarativeFilters();
 
         for (Map.Entry<String,List<Class<? extends Descriptor>>> entry : getDeclarativeDirectives().entrySet()) {
+            System.out.println("Generating docs for directive " + entry.getKey());
             Map<String, List<Descriptor>> pluginDescMap = new HashMap<>();
 
             for (Class<? extends Descriptor> d : entry.getValue()) {
+                Predicate<Descriptor> filter = filters.get(d);
+                System.out.println(" - Loading descriptors of type " + d.getSimpleName() + " with filter: " + (filter != null));
                 pluginDescMap = processDescriptors(d, pluginDescMap, filters.get(d));
             }
 

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -1,33 +1,44 @@
 package org.jenkinsci.pipeline_steps_doc_generator;
 
+import hudson.FilePath;
+import hudson.Launcher;
 import hudson.MockJenkins;
 import hudson.PluginManager;
 import hudson.init.InitMilestone;
 import hudson.init.InitStrategy;
+import hudson.model.Descriptor;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.ParameterDefinition;
 import hudson.security.ACL;
+import hudson.triggers.TriggerDescriptor;
 import jenkins.InitReactorRunner;
 import jenkins.model.Jenkins;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jvnet.hudson.reactor.*;
-import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.*;
 
@@ -38,9 +49,12 @@ public class PipelineStepExtractor {
     @Option(name="-homeDir",usage="Root directory of the plugin folder.  This serves as the root directory of the PluginManager.")
     public String homeDir = null;
     
-    @Option(name="-asciiDest",usage="Full path of the location to save the asciidoc.  Defaults to ./allAscii")
+    @Option(name="-asciiDest",usage="Full path of the location to save the steps asciidoc.  Defaults to ./allAscii")
     public String asciiDest = null;
-    
+
+    @Option(name="-declarativeDest",usage="Full path of the location to save the Declarative asciidoc. Defaults to ./declarative")
+    public String declarativeDest = null;
+
     public static void main(String[] args){
         PipelineStepExtractor pse = new PipelineStepExtractor();
         try{
@@ -52,6 +66,7 @@ public class PipelineStepExtractor {
         try{
             Map<String, Map<String, List<StepDescriptor>>> steps = pse.findSteps();
             pse.generateAscii(steps, pse.pluginManager);
+            pse.generateDeclarativeAscii();
         } catch(Exception ex){
             System.out.println("Error in finding all the steps");
         }
@@ -205,5 +220,93 @@ public class PipelineStepExtractor {
                 //continue to next plugin
             }
         }
+    }
+
+    public void generateDeclarativeAscii() {
+        File declDest;
+        if (declarativeDest != null) {
+            declDest = new File(declarativeDest);
+        } else {
+            declDest = new File("declarative");
+        }
+        declDest.mkdirs();
+        String declPath = declDest.getAbsolutePath();
+
+        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = getDeclarativeFilters();
+
+        for (Map.Entry<String,List<Class<? extends Descriptor>>> entry : getDeclarativeDirectives().entrySet()) {
+            Map<String, List<Descriptor>> pluginDescMap = new HashMap<>();
+
+            for (Class<? extends Descriptor> d : entry.getValue()) {
+                pluginDescMap = processDescriptors(d, pluginDescMap, filters.get(d));
+            }
+
+            String whole9yards = ToAsciiDoc.generateDirectiveHelp(entry.getKey(), pluginDescMap, true);
+
+            try{
+                FileUtils.writeStringToFile(new File(declPath, entry.getKey() + ".adoc"), whole9yards, StandardCharsets.UTF_8);
+            } catch (Exception ex){
+                System.out.println("Error generating directive file for " + entry.getKey() + ".  Skip.");
+                //continue to next directive
+            }
+        }
+    }
+
+    private Map<String, List<Descriptor>> processDescriptors(@Nonnull Class<? extends Descriptor> c,
+                                                             @Nonnull Map<String, List<Descriptor>> descMap,
+                                                             @CheckForNull Predicate<Descriptor> filter) {
+        // If no filter was specified, default to true.
+        if (filter == null) {
+            filter = (d) -> true;
+        }
+        List<? extends Descriptor> descriptors = pluginManager.getPluginStrategy().findComponents(c);
+        final Map<String, String> descriptorsToPlugin = pluginManager.uberPlusClassLoader.getByPlugin();
+
+        for (Descriptor d : descriptors.stream().filter(filter).collect(Collectors.toList())) {
+            String pluginName = descriptorsToPlugin.get(d.getClass().getName());
+            if (pluginName != null) {
+                pluginName = pluginName.trim();
+            } else {
+                pluginName = "core";
+            }
+            if (!descMap.containsKey(pluginName)) {
+                descMap.put(pluginName, new ArrayList<>());
+            }
+            descMap.get(pluginName).add(d);
+        }
+        return descMap;
+    }
+
+    private Map<String,List<Class<? extends Descriptor>>> getDeclarativeDirectives() {
+        Map<String,List<Class<? extends Descriptor>>> directives = new HashMap<>();
+
+        directives.put("agent", Arrays.asList(DeclarativeAgentDescriptor.class));
+        directives.put("options", Arrays.asList(JobPropertyDescriptor.class, DeclarativeOptionDescriptor.class, StepDescriptor.class));
+        directives.put("triggers", Arrays.asList(TriggerDescriptor.class));
+        directives.put("parameters", Arrays.asList(ParameterDefinition.ParameterDescriptor.class));
+        directives.put("when", Arrays.asList(DeclarativeStageConditionalDescriptor.class));
+
+        return directives;
+    }
+
+    private Map<Class<? extends Descriptor>, Predicate<Descriptor>> getDeclarativeFilters() {
+        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = new HashMap<>();
+
+        filters.put(StepDescriptor.class, d -> {
+            if (d instanceof StepDescriptor) {
+                StepDescriptor s = (StepDescriptor) d;
+                // Note that this is lifted from org.jenkinsci.plugins.pipeline.modeldefinition.model.Options, with the
+                // blocked steps hardcoded. This could be better.
+                return s.takesImplicitBlockArgument() &&
+                        !s.getRequiredContext().contains(Launcher.class) &&
+                        !s.getRequiredContext().contains(FilePath.class) &&
+                        !s.getFunctionName().equals("node") &&
+                        !s.getFunctionName().equals("stage");
+            } else {
+                return false;
+            }
+        });
+
+        return filters;
     }
 }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -214,14 +214,16 @@ public class ToAsciiDoc {
         }
         whole9yards.append("== ").append(directiveName).append("\n\n");
         for (Map.Entry<String, List<Descriptor>> entry : descsByPlugin.entrySet()) {
-            String pluginName = entry.getKey();
-            if (pluginName.equals("core")) {
-                whole9yards.append("Jenkins Core:\n\n");
-            } else {
-                whole9yards.append("plugin:").append(pluginName).append("[View this plugin on the Plugins Index]\n\n");
-            }
-            for (Descriptor d : entry.getValue()) {
-                whole9yards.append(generateDescribableHelp(d));
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                String pluginName = entry.getKey();
+                if (pluginName.equals("core")) {
+                    whole9yards.append("Jenkins Core:\n\n");
+                } else {
+                    whole9yards.append("plugin:").append(pluginName).append("[View this plugin on the Plugins Index]\n\n");
+                }
+                for (Descriptor d : entry.getValue()) {
+                    whole9yards.append(generateDescribableHelp(d));
+                }
             }
         }
 


### PR DESCRIPTION
[INFRA-1053](https://issues.jenkins-ci.org/browse/INFRA-1053)

This is the first work in that direction - it may make sense to keep
everything in here after all rather than splitting things up as in #11 

This generates (at least in theory) Asciidoc for the Declarative
directives that contain Describables - i.e., `agent`, `when`,
`options`, `triggers`, and `parameters`. More work is needed to
special-case `post` due to its conditions not being
Describables. Grr. I have regrets there.

Also, this depends on https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/219 to actually have help info for the Declarative-specific extension points.