### PR TITLE
Try-catch for computing display name

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/HyperLocalPluginManger.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/HyperLocalPluginManger.java
@@ -460,7 +460,7 @@ public class HyperLocalPluginManger extends LocalPluginManager{
                         throw new AssertionError();
 
                     if(type.isAssignableFrom(extType)) {
-                        Object instance = item.instance();
+                        Object instance = safeInstance(item);
                         if(instance!=null)
                             result.add(new ExtensionComponent<>(type.cast(instance),item.annotation()));
                     }
@@ -472,6 +472,15 @@ public class HyperLocalPluginManger extends LocalPluginManager{
             }
 
             return result;
+        }
+
+        private Object safeInstance(IndexItem<Extension, Object> item) {
+            try {
+                return item.instance();
+            } catch (Exception | Error e) {
+                LOG.log(Level.WARNING, "Cannot instantiate " + item.className(), e);
+            }
+            return null;
         }
 
         public void scout(Class<?> extensionType, ClassLoader cl) {

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -159,8 +159,8 @@ public class ToAsciiDoc {
      * For delegate steps adds example without Symbol.
      */
     public static String generateStepHelp(QuasiDescriptor d){
-        StringBuilder mkDesc = new StringBuilder(header(3)).append(" `").append(d.getSymbol()).append("`: ").append(d.real.getDisplayName()).append("\n");
-        mkDesc.append("++++\n");
+        StringBuilder mkDesc = new StringBuilder(header(3)).append(" `").append(d.getSymbol()).append("`: ");
+        mkDesc.append(getDisplayName(d.real)).append("\n++++\n");
         try {
             Optional<Descriptor<?>> delegateExample = PipelineStepExtractor.getMetaDelegates(d.real)
                 .filter(sub -> SymbolLookup.getSymbolValue(sub.clazz).isEmpty()).findFirst();
@@ -178,7 +178,16 @@ public class ToAsciiDoc {
         return mkDesc.append("\n\n\n++++\n").toString();
     }
 
-	private static void appendSimpleStepDescription(StringBuilder mkDesc, Class<?> clazz) throws IOException {
+    private static String getDisplayName(Descriptor<?> d) {
+        try {
+            return d.getDisplayName();
+        } catch(Exception | Error e){
+            LOG.log(Level.WARNING, "Cannot get display name of " + d.clazz, e);
+        }
+        return "(no description)";
+    }
+
+    private static void appendSimpleStepDescription(StringBuilder mkDesc, Class<?> clazz) throws IOException {
         try {
             mkDesc.append(generateHelp(new DescribableModel<>(clazz), true));
         } catch (Exception ex) {
@@ -213,7 +222,8 @@ public class ToAsciiDoc {
         } else {
             Set<String> symbols = SymbolLookup.getSymbolValue(d);
             if (!symbols.isEmpty()) {
-                StringBuilder mkDesc = new StringBuilder(header(3)).append(" `").append(symbols.iterator().next()).append("`: ").append(d.getDisplayName()).append("\n");
+                StringBuilder mkDesc = new StringBuilder(header(3)).append(" `").append(symbols.iterator().next()).append("`: ");
+                mkDesc.append(getDisplayName(d)).append("\n");
                 try {
                     mkDesc.append(generateHelp(new DescribableModel<>(d.clazz), true)).append("\n\n");
                 } catch (Exception | Error ex) {


### PR DESCRIPTION
Some plugins may throw an error when 
* getting the display name of a step (e.g. [FuzzBuildStep](https://github.com/jenkinsci/defensics-plugin/blob/d1a21007805d13e098859840b1508c36e9a93d34/src/main/java/com/synopsys/defensics/jenkins/FuzzBuildStep.java))
* initializing the descriptor (e.g. if a class has step descriptor but does not implement `Step`, see https://github.com/alexanderlz/jenkins-pagerduty-plugin/pull/41)

This PR adds checks for these exceptions.