### PR TITLE
Update components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: master
+  reviewers:
+  - kwhetstone
+  - MarkEWaite
+  labels:
+  - dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .*
 !.gitignore
 !.github/
+secrets/
 target/
 work
 /nbactions.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iws
 .*
 !.gitignore
+!.github/
 target/
 work
 /nbactions.xml

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ From this repository, with others in relative positions:
 ```bash
 rm -v ../jenkins.io/content/doc/pipeline/steps/*.adoc
 make -C ../../jenkinsci/workflow-aggregator-plugin/demo copy-plugins
-mvn "-Dexec.args=-classpath %classpath org.jenkinsci.pipeline_steps_doc_generator.PipelineStepExtractor -homeDir $(pwd)/../../jenkinsci/workflow-aggregator-plugin/demo -asciiDest $(pwd)/../jenkins.io/content/doc/pipeline/steps -declarativeDest /tmp/declarative" -Dexec.executable=$(which java) org.codehaus.mojo:exec-maven-plugin:1.5.0:exec
+mvn "-Dexec.args=-classpath %classpath org.jenkinsci.pipeline_steps_doc_generator.PipelineStepExtractor -homeDir $(pwd)/../../jenkinsci/workflow-aggregator-plugin/demo -asciiDest $(pwd)/../jenkins.io/content/doc/pipeline/steps -declarativeDest /tmp/declarative" -Dexec.executable=$(which java) org.codehaus.mojo:exec-maven-plugin:3.0.0:exec
 make -C ../jenkins.io run
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.5.0</version>
+      <version>3.7.7</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>net.java.sezpoz</groupId>
       <artifactId>sezpoz</artifactId>
-      <version>1.12</version>
+      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.9.2</version>
+      <version>1.13.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             </manifest>
           </archive>
         </configuration>
-        <version>3.0.2</version>
+        <version>3.2.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
-      <version>1.2.4</version>
+      <version>1.7.2</version>
     </dependency>
     <dependency>
       <groupId>net.java.sezpoz</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.4</version>
+      <version>2.23</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:deprecation</arg>
+            <arg>-Xlint:all,-options,-path</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
@@ -67,7 +77,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-      <version>2.263.3</version>
+      <version>2.277</version> <!-- for ACL.impersonate2() and acegi to Spring Security conversion -->
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/src/assembly.xml
+++ b/src/assembly.xml
@@ -1,7 +1,6 @@
 <assembly>
   <id>bin</id>
   <formats>
-    <format>dir</format>
     <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/src/assembly.xml
+++ b/src/assembly.xml
@@ -1,6 +1,7 @@
 <assembly>
   <id>bin</id>
   <formats>
+    <format>dir</format>
     <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -30,8 +30,8 @@ import org.jvnet.hudson.reactor.*;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -291,8 +291,8 @@ public class PipelineStepExtractor {
         }
     }
 
-    private Map<String, List<Descriptor>> processDescriptors(@Nonnull Class<? extends Descriptor> c,
-                                                             @Nonnull Map<String, List<Descriptor>> descMap,
+    private Map<String, List<Descriptor>> processDescriptors(@NonNull Class<? extends Descriptor> c,
+                                                             @NonNull Map<String, List<Descriptor>> descMap,
                                                              @CheckForNull Predicate<Descriptor> filter) {
         // If no filter was specified, default to true.
         if (filter == null) {

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -173,7 +173,7 @@ public class PipelineStepExtractor {
 
     private static Descriptor<?> getDescriptor(DescribableModel<?> delegateOptionSchema) {
         Class<?> delegateOptionType = delegateOptionSchema.getType();
-        return Jenkins.getInstance().getDescriptor(delegateOptionType.asSubclass(Describable.class));
+        return Jenkins.get().getDescriptor(delegateOptionType.asSubclass(Describable.class));
     }
 
     /**


### PR DESCRIPTION
## Update components

Resolve compilation warnings and update the components to the latest versions.

### Resolve Jenkins deprecation warnings

- Use Jenkins 2.277 for access to the Spring security framework
- Use Spring security context instead of acegi
- Use Jenkins.get() as non-deprecated API
- Use findbugs annotations instead of javax annotations

### Update to latest Jenkins plugins

- Use workflow step api plugin 2.23 - latest release
- Use Pipeline: Declarative Extension Points API plugin 1.7.2

### Update to latest maven component versions

- Use Apache commons-io 2.8.0 - latest release
- Use net.java.sezpoz 1.13 - latest release
- Use mockito-core 3.7.7 - latest release
- Use jsoup 1.13.1 - latest release
- Use maven jar plugin 3.2.0 - latest release
- Use latest exec maven plugin release in README

### Resolve warnings

- Set maven source encoding to UTF-8

### Automate dependency update checks

- Configure dependabot

### Minor improvements

- Ignore secrets directory from README instructions

CC: @zbynek, @timja

## Exploratory Test Report

I confirmed that the README instructions work as expected and that the page generated by the docs generator after the changes looks reasonable.

* Before the changes, the master branch generated a page that did not include the `withCredentials` step.
* After the changes, this development branch generates the same page and adds the `withCredentials` step as well.  I'm not clear why there was a difference, but that seems like an improvement to me.

I compared the contents of the generated zip file before the changes and after the changes.  The contents are the same with the one exception that the pipeline-steps-doc-generator-1.0-SNAPSHOT.jar file is different on this branch than on the master branch.
