### PR TITLE
Match javax.servlet-api version in Jenkins core/pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Match servlet-api from Jenkins core/pom.xml

Java seems to have changed the name of the artifact.  This uses the same artifact and version as is mentioned in Jenkins core/pom.xml as a provided dependency.
