### PR TITLE
Special case for Object and Step descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
       <artifactId>jsoup</artifactId>
       <version>1.13.1</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <repositories>

--- a/src/main/java/hudson/MockExtensionLists.java
+++ b/src/main/java/hudson/MockExtensionLists.java
@@ -4,9 +4,12 @@
 
 package hudson;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+
+import hudson.model.listeners.SaveableListener;
 import org.jenkinsci.pipeline_steps_doc_generator.HyperLocalPluginManger;
 
 import static org.mockito.Mockito.*;
@@ -20,6 +23,11 @@ public class MockExtensionLists {
     private static Map<String, ExtensionList<?>> extensionLists = new HashMap<String, ExtensionList<?>>();
 
     public ExtensionList<?> getMockExtensionList(HyperLocalPluginManger hlpm, Jenkins hudson, Class<?> type) {
+        if (SaveableListener.class.equals(type)) {
+            ExtensionList<?> ret = mock(ExtensionList.class);
+            doReturn(Collections.emptyIterator()).when(ret).iterator();
+            return ret;
+        }
         if(extensionLists.get(type.getName()) != null) {
             return extensionLists.get(type.getName());
         } else {

--- a/src/main/java/hudson/MockJenkins.java
+++ b/src/main/java/hudson/MockJenkins.java
@@ -25,8 +25,17 @@ import static org.mockito.Mockito.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import java.io.File;
+import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Set;
 
 public class MockJenkins {
      private MockExtensionLists mockLookup = new MockExtensionLists();
@@ -45,10 +54,14 @@ public class MockJenkins {
          when(mockJenkins.getInitLevel()).thenReturn(InitMilestone.COMPLETED);
          when(mockJenkins.getInstallState()).thenReturn(InstallState.TEST);
          when(mockJenkins.getComputers()).thenReturn(new Computer[0]);
+         when(mockJenkins.getRootDir()).thenReturn(new File(System.getProperty("java.io.tmpdir")));
          try {
              Field lookup = mockJenkins.getClass().getField("lookup");
              lookup.setAccessible(true);
              lookup.set(mockJenkins, new Lookup());
+             Field servletContext = mockJenkins.getClass().getField("servletContext");
+             servletContext.setAccessible(true);
+             servletContext.set(mockJenkins, mock(ServletContext.class));
          } catch (NoSuchFieldException | IllegalAccessException e) {
              e.printStackTrace();
          }

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/DescribeMe.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/DescribeMe.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.pipeline_steps_doc_generator;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.HashMap;
+
+class DescribeMe {
+    @DataBoundConstructor
+    public DescribeMe(HashMap<String, String> s) {
+        this.s = s;
+    }
+
+    public HashMap<String, String> s;
+}

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciidocTest.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciidocTest.java
@@ -1,0 +1,20 @@
+package org.jenkinsci.pipeline_steps_doc_generator;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ToAsciidocTest {
+
+    @Test
+    public void testDescribeType() {
+        DescribableModel<DescribeMe> model = new DescribableModel<>(DescribeMe.class);
+        try {
+            String desc = ToAsciiDoc.describeType(model.getParameter("s").getType(), "");
+            assertEquals("<code>java.util.HashMap&lt;java.lang.String, java.lang.String&gt;</code>", desc.trim());
+        } catch (Exception e) {
+            fail("Cannot describe map " + e);
+        }
+    }
+}


### PR DESCRIPTION
Problems:
* The generator will try to nest description of all steps (or even worse, objects) in cases where step takes other steps or generic objects as arguments.  I think the only reason this doesn't cause infinite recursion is that an exception is thrown while describing some of the steps, causing an incomplete description.
* If a type is not supported by `structs` plugin (such as java.util.Map), only the last "word" of the type is printed.

Both problems shown in a screenshot for [Jira pipeline steps plugin](https://www.jenkins.io/doc/pipeline/steps/jira-steps/) 
![image](https://user-images.githubusercontent.com/1105305/107848489-12cffb00-6df4-11eb-8a31-57b7635340ef.png)

This PR will show hardcoded description for Object and BuildStep types as well as list/array types derived from those two and show full Java class name for the unsupported classes.
![image](https://user-images.githubusercontent.com/1105305/107848599-f41e3400-6df4-11eb-94ae-851cd047b3e8.png)
