### PR TITLE
Remove file leak detector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir('docFolder') {
                     checkout scm
-                    sh 'mvn -s ../settings.xml clean install -DskipTests'
+                    sh 'mvn -s ../settings.xml --no-transfer-progress clean install -DskipTests'
                     sh 'mv ../plugins . && java -verbose:gc -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 dir('docFolder') {
                     checkout scm
                     sh 'mvn -s ../settings.xml clean install -DskipTests'
-                    sh 'mv ../plugins . && java -verbose:gc -javaagent:./contrib/file-leak-detector.jar -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
+                    sh 'mv ../plugins . && java -verbose:gc -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
                 }
             }
         }


### PR DESCRIPTION
File leak detector not ported to Java 11

Don't forget to delete the pull request branch after merging or closing the pull request.

CC: @zbynek and @halkeye