### PR TITLE
Remove kwhetstone from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
   open-pull-requests-limit: 10
   target-branch: master
   reviewers:
-  - kwhetstone
   - MarkEWaite
   labels:
   - dependencies


### PR DESCRIPTION
https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/78#issuecomment-890655008

> Dependabot tried to add @kwhetstone and @MarkEWaite as reviewers to this PR, but received the following error from GitHub
```
POST https://api.github.com/repos/jenkins-infra/pipeline-steps-doc-generator/pulls/78/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the jenkins-infra/pipeline-steps-doc-generator repository. // See: https://docs.github.com/rest/reference/pulls#request-reviewers-for-a-pull-request
```

@kwhetstone looks like you no longer have access here.

Is it fine to remove you from dependabot or do you want access restored?
