### PR TITLE
Use loadClass instead of removed _findLoadedClass

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/HyperLocalPluginManger.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/HyperLocalPluginManger.java
@@ -236,7 +236,7 @@ public class HyperLocalPluginManger extends LocalPluginManager{
             if (FAST_LOOKUP) {
                 for (PluginWrapper p : activePlugins) {
                     try {
-                        Class<?> c = ClassLoaderReflectionToolkit._findLoadedClass(p.classLoader, name);
+                        Class<?> c = ClassLoaderReflectionToolkit.loadClass(p.classLoader, name);
                         if (c != null) {
                             synchronized (loaded) {
                                 loaded.put(name, c);
@@ -247,7 +247,7 @@ public class HyperLocalPluginManger extends LocalPluginManager{
                             return c;
                         }
                         // calling findClass twice appears to cause LinkageError: duplicate class def
-                        c = ClassLoaderReflectionToolkit._findClass(p.classLoader, name);
+                        c = ClassLoaderReflectionToolkit.loadClass(p.classLoader, name);
                         synchronized (loaded) {
                             loaded.put(name, c);
                         }


### PR DESCRIPTION
## Use loadClass, not deprecated _findXXX()

Deprecation message suggested the replacement.

Will allow #113 to be merged since Jenkins 2.324 removed the deprecated method.  Compilation fails on #113 without this change
