### PR TITLE
Update README: add optional instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ rm -v ../jenkins.io/content/doc/pipeline/steps/*.adoc
 
 * Run the `Makefile` created in [Step 4](#4-create-makefile).
 
+>**OPTIONAL:** Add `plugins` folder to the `.gitignore` file of all the plugins on which you wish to run the code to prevent flooding the git tracker of your IDE/Editor.
+
 ```Shell
 make -C ../../jenkinsci/schedule-build-plugin copy-plugins
 ```


### PR DESCRIPTION
Running the code on a plugin creates a folder called `plugins` and adds all the files to it. For a plugin such as the `git-plugin`, the number of files added can be more than a thousand, ultimately flooding the git tracker of an IDE/Editor. Thus, I have added an optional step before running the commands to add the `plugins` folder created in every plugin to its respective `.gitignore`.