### PR TITLE
chore(pipeline) use VM agent instead of containe to ensure enough disk space

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 pipeline {
-    agent { label 'vm' }
+    agent { label 'vm && linux' }
     triggers {
         cron('H H * * 0')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
         stage('Run Indexer') {
             steps {
                 dir('pluginFolder') {
-                    sh 'java -verbose:gc -jar ./target/*-bin/extension-indexer*.jar -plugins ./plugins && mv plugins ..'
+                    sh 'java -verbose:gc -XshowSettings:vm -jar ./target/*-bin/extension-indexer*.jar -plugins ./plugins && mv plugins ..'
                 }
             }
         }
@@ -44,7 +44,7 @@ pipeline {
                 dir('docFolder') {
                     checkout scm
                     sh 'mvn -s ../settings.xml --no-transfer-progress clean install -DskipTests'
-                    sh 'mv ../plugins . && java -verbose:gc -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
+                    sh 'mv ../plugins . && java -verbose:gc -XshowSettings:vm -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 pipeline {
-    agent { label 'maven-11' }
+    agent { label 'vm' }
     triggers {
         cron('H H * * 0')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
 
     options {
         timestamps()
+        timeout(time: 1, unit: 'HOURS')
     }
 
     stages {


### PR DESCRIPTION
The builds of this project are currently stuck after ~18h and had been stopped manually.

There are 2 kinds of errors:

- On the PR #153 , there are messages about `java.io.IOException: No space left on device` during the stage `Run Indexer` leading to the build being stuck (agent unresponsive)
- On the principal branch, it's harder to tell. The agent suddenly stop responding. It's hard to tell if it is being OOM killed (the GC does not seem to show that much of memory used)

Closes https://github.com/jenkins-infra/helpdesk/issues/2883

This PR introduces the folowing pipelines changes trying to improve this situation:

- Switch agent from a container to a VM:
  - Kernel memory not multi-tenant: the java process will be at ease with less memory pressure (and clearly more memory as the 8 Gb of default `maben-11` pod)
  - Bigger hard disk: pod agents have a default of 20Gb for their root disk while 90gb for VMs

- Add a timeout of 1 hour for this pipeline (usualy less than 25 min)

- Add a flag `-XshowSettings:vm` to the java processes to prints on the log output which amount of memory is seen (easier to debug GC behaviors)