### PR TITLE
Describe why we depend on the weekly release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-      <version>2.354</version> <!-- for ACL.impersonate2() and acegi to Spring Security conversion -->
+      <version>2.354</version> <!-- weekly release for latest API's -->
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
## Describe why we depend on weekly releases in this tool

The comment previously described specific API's that have long since appeared in an LTS.  The most recent API's are available in weekly releases before they are available in LTS releases.
