### PR TITLE
Separate declarative steps generation from main class

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
@@ -1,0 +1,133 @@
+package org.jenkinsci.pipeline_steps_doc_generator;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.ParameterDefinition;
+import hudson.triggers.TriggerDescriptor;
+
+public class DeclarativeSteps {
+    private static final Logger LOG = Logger.getLogger(DeclarativeSteps.class.getName());
+    private static final List<String> blockedOptionSteps = Arrays.asList("node", "stage", "withEnv", "script", "withCredentials");
+    private static final List<Class<?>> blockedOptionStepContexts = Arrays.asList(Launcher.class, FilePath.class, Computer.class);
+
+    public void generateDeclarativeAscii(String declarativeDest, HyperLocalPluginManger pluginManager) {
+        File declDest;
+        if (declarativeDest != null) {
+            declDest = new File(declarativeDest);
+        } else {
+            declDest = new File("declarative");
+        }
+        declDest.mkdirs();
+        String declPath = declDest.getAbsolutePath();
+
+        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = getDeclarativeFilters();
+
+        for (Map.Entry<String,List<Class<? extends Descriptor>>> entry : getDeclarativeDirectives().entrySet()) {
+            LOG.info("Generating docs for directive " + entry.getKey());
+            Map<String, List<Descriptor>> pluginDescMap = new HashMap<>();
+
+            for (Class<? extends Descriptor> d : entry.getValue()) {
+                Predicate<Descriptor> filter = filters.get(d);
+                LOG.info(" - Loading descriptors of type " + d.getSimpleName() + " with filter: " + (filter != null));
+                pluginDescMap = processDescriptors(d, pluginDescMap, filter, pluginManager);
+            }
+
+            String whole9yards = ToAsciiDoc.generateDirectiveHelp(entry.getKey(), pluginDescMap, true);
+
+            try{
+                FileUtils.writeStringToFile(new File(declPath, entry.getKey() + ".adoc"), whole9yards, StandardCharsets.UTF_8);
+            } catch (Exception ex) {
+                LOG.log(Level.SEVERE, "Error generating directive file for " + entry.getKey() + ".  Skip.", ex);
+                //continue to next directive
+            }
+        }
+    }
+
+    private Map<String, List<Descriptor>> processDescriptors(@NonNull Class<? extends Descriptor> c,
+                                                             @NonNull Map<String, List<Descriptor>> descMap,
+                                                             @CheckForNull Predicate<Descriptor> filter, 
+                                                             HyperLocalPluginManger pluginManager) {
+        // If no filter was specified, default to true.
+        if (filter == null) {
+            filter = (d) -> true;
+        }
+        List<? extends Descriptor> descriptors = pluginManager.getPluginStrategy().findComponents(c);
+        final Map<String, String> descriptorsToPlugin = pluginManager.uberPlusClassLoader.getByPlugin();
+
+        // Only include steps or describables with symbols.
+        Predicate<Descriptor> fullFilter = filter.and(d -> {
+            if (d instanceof StepDescriptor) {
+                return true;
+            } else {
+                Set<String> symbols = SymbolLookup.getSymbolValue(d);
+                return !symbols.isEmpty();
+            }
+        });
+
+        descriptors.stream().filter(fullFilter).forEach(d -> {
+            String pluginName = descriptorsToPlugin.get(d.getClass().getName());
+            if (pluginName != null) {
+                pluginName = pluginName.trim();
+            } else {
+                pluginName = "core";
+            }
+            descMap.computeIfAbsent(pluginName, k -> new ArrayList<>()).add(d);
+        });
+        return descMap;
+    }
+
+    private Map<String,List<Class<? extends Descriptor>>> getDeclarativeDirectives() {
+        Map<String,List<Class<? extends Descriptor>>> directives = new HashMap<>();
+
+        directives.put("agent", Arrays.asList(DeclarativeAgentDescriptor.class));
+        directives.put("options", Arrays.asList(JobPropertyDescriptor.class, DeclarativeOptionDescriptor.class, StepDescriptor.class));
+        directives.put("triggers", Arrays.asList(TriggerDescriptor.class));
+        directives.put("parameters", Arrays.asList(ParameterDefinition.ParameterDescriptor.class));
+        directives.put("when", Arrays.asList(DeclarativeStageConditionalDescriptor.class));
+
+        return directives;
+    }
+    
+    private Map<Class<? extends Descriptor>, Predicate<Descriptor>> getDeclarativeFilters() {
+        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = new HashMap<>();
+
+        filters.put(StepDescriptor.class, d -> {
+            if (d instanceof StepDescriptor) {
+                StepDescriptor s = (StepDescriptor) d;
+                // Note that this is lifted from org.jenkinsci.plugins.pipeline.modeldefinition.model.Options, with the
+                // blocked steps hardcoded. This could be better.
+                return s.takesImplicitBlockArgument() &&
+                        s.getRequiredContext().stream().noneMatch(blockedOptionStepContexts::contains) &&
+                        !blockedOptionSteps.contains(s.getFunctionName());
+            } else {
+                return false;
+            }
+        });
+
+        return filters;
+    }
+}

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -1,57 +1,46 @@
 package org.jenkinsci.pipeline_steps_doc_generator;
 
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.MockJenkins;
-import hudson.PluginManager;
-import hudson.PluginWrapper;
-import hudson.init.InitMilestone;
-import hudson.init.InitStrategy;
-import hudson.model.Computer;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.model.JobPropertyDescriptor;
-import hudson.model.ParameterDefinition;
-import hudson.security.ACL;
-import hudson.security.ACLContext;
-import hudson.triggers.TriggerDescriptor;
-import jenkins.InitReactorRunner;
-import jenkins.model.Jenkins;
-import org.apache.commons.io.FileUtils;
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
-import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
-import org.jenkinsci.plugins.structs.SymbolLookup;
-import org.jenkinsci.plugins.structs.describable.DescribableModel;
-import org.jenkinsci.plugins.structs.describable.DescribableParameter;
-import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType;
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
-import org.jvnet.hudson.reactor.*;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.*;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableParameter;
+import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jvnet.hudson.reactor.Reactor;
+import org.jvnet.hudson.reactor.ReactorException;
+import org.jvnet.hudson.reactor.Task;
+import org.jvnet.hudson.reactor.TaskBuilder;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import hudson.MockJenkins;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
+import hudson.init.InitMilestone;
+import hudson.init.InitStrategy;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import jenkins.InitReactorRunner;
+import jenkins.model.Jenkins;
 
 /**
  * Process and find all the Pipeline steps definied in Jenkins plugins.
@@ -81,7 +70,7 @@ public class PipelineStepExtractor {
         try{
             Map<String, Map<String, List<QuasiDescriptor>>> steps = pse.findSteps();
             pse.generateAscii(steps, pse.pluginManager);
-            pse.generateDeclarativeAscii();
+            pse.getDeclarativeSteps();
         } catch(Exception ex){
             LOG.log(Level.SEVERE, "Error in finding all the steps", ex);
         }
@@ -258,102 +247,9 @@ public class PipelineStepExtractor {
         }
     }
 
-    public void generateDeclarativeAscii() {
-        File declDest;
-        if (declarativeDest != null) {
-            declDest = new File(declarativeDest);
-        } else {
-            declDest = new File("declarative");
-        }
-        declDest.mkdirs();
-        String declPath = declDest.getAbsolutePath();
-
-        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = getDeclarativeFilters();
-
-        for (Map.Entry<String,List<Class<? extends Descriptor>>> entry : getDeclarativeDirectives().entrySet()) {
-            LOG.info("Generating docs for directive " + entry.getKey());
-            Map<String, List<Descriptor>> pluginDescMap = new HashMap<>();
-
-            for (Class<? extends Descriptor> d : entry.getValue()) {
-                Predicate<Descriptor> filter = filters.get(d);
-                LOG.info(" - Loading descriptors of type " + d.getSimpleName() + " with filter: " + (filter != null));
-                pluginDescMap = processDescriptors(d, pluginDescMap, filter);
-            }
-
-            String whole9yards = ToAsciiDoc.generateDirectiveHelp(entry.getKey(), pluginDescMap, true);
-
-            try{
-                FileUtils.writeStringToFile(new File(declPath, entry.getKey() + ".adoc"), whole9yards, StandardCharsets.UTF_8);
-            } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "Error generating directive file for " + entry.getKey() + ".  Skip.", ex);
-                //continue to next directive
-            }
-        }
+    public void getDeclarativeSteps() {
+        DeclarativeSteps ds = new DeclarativeSteps();
+        ds.generateDeclarativeAscii(declarativeDest, pluginManager);
     }
 
-    private Map<String, List<Descriptor>> processDescriptors(@NonNull Class<? extends Descriptor> c,
-                                                             @NonNull Map<String, List<Descriptor>> descMap,
-                                                             @CheckForNull Predicate<Descriptor> filter) {
-        // If no filter was specified, default to true.
-        if (filter == null) {
-            filter = (d) -> true;
-        }
-        List<? extends Descriptor> descriptors = pluginManager.getPluginStrategy().findComponents(c);
-        final Map<String, String> descriptorsToPlugin = pluginManager.uberPlusClassLoader.getByPlugin();
-
-        // Only include steps or describables with symbols.
-        Predicate<Descriptor> fullFilter = filter.and(d -> {
-            if (d instanceof StepDescriptor) {
-                return true;
-            } else {
-                Set<String> symbols = SymbolLookup.getSymbolValue(d);
-                return !symbols.isEmpty();
-            }
-        });
-
-        descriptors.stream().filter(fullFilter).forEach(d -> {
-            String pluginName = descriptorsToPlugin.get(d.getClass().getName());
-            if (pluginName != null) {
-                pluginName = pluginName.trim();
-            } else {
-                pluginName = "core";
-            }
-            descMap.computeIfAbsent(pluginName, k -> new ArrayList<>()).add(d);
-        });
-        return descMap;
-    }
-
-    private Map<String,List<Class<? extends Descriptor>>> getDeclarativeDirectives() {
-        Map<String,List<Class<? extends Descriptor>>> directives = new HashMap<>();
-
-        directives.put("agent", Arrays.asList(DeclarativeAgentDescriptor.class));
-        directives.put("options", Arrays.asList(JobPropertyDescriptor.class, DeclarativeOptionDescriptor.class, StepDescriptor.class));
-        directives.put("triggers", Arrays.asList(TriggerDescriptor.class));
-        directives.put("parameters", Arrays.asList(ParameterDefinition.ParameterDescriptor.class));
-        directives.put("when", Arrays.asList(DeclarativeStageConditionalDescriptor.class));
-
-        return directives;
-    }
-
-    private static final List<String> blockedOptionSteps = Arrays.asList("node", "stage", "withEnv", "script", "withCredentials");
-    private static final List<Class<?>> blockedOptionStepContexts = Arrays.asList(Launcher.class, FilePath.class, Computer.class);
-
-    private Map<Class<? extends Descriptor>, Predicate<Descriptor>> getDeclarativeFilters() {
-        Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = new HashMap<>();
-
-        filters.put(StepDescriptor.class, d -> {
-            if (d instanceof StepDescriptor) {
-                StepDescriptor s = (StepDescriptor) d;
-                // Note that this is lifted from org.jenkinsci.plugins.pipeline.modeldefinition.model.Options, with the
-                // blocked steps hardcoded. This could be better.
-                return s.takesImplicitBlockArgument() &&
-                        s.getRequiredContext().stream().noneMatch(blockedOptionStepContexts::contains) &&
-                        !blockedOptionSteps.contains(s.getFunctionName());
-            } else {
-                return false;
-            }
-        });
-
-        return filters;
-    }
 }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -70,7 +70,7 @@ public class PipelineStepExtractor {
         try{
             Map<String, Map<String, List<QuasiDescriptor>>> steps = pse.findSteps();
             pse.generateAscii(steps, pse.pluginManager);
-            pse.getDeclarativeSteps();
+            pse.generateDeclarativeSteps();
         } catch(Exception ex){
             LOG.log(Level.SEVERE, "Error in finding all the steps", ex);
         }
@@ -247,7 +247,7 @@ public class PipelineStepExtractor {
         }
     }
 
-    public void getDeclarativeSteps() {
+    public void generateDeclarativeSteps() {
         DeclarativeSteps ds = new DeclarativeSteps();
         ds.generateDeclarativeAscii(declarativeDest, pluginManager);
     }


### PR DESCRIPTION
This pull request shifts the functions to generate declarative steps (earlier in the main class) into a new class.

Checklist of tasks done: 
- [x] Create new class `DeclarativeSteps.java`.
- [x] Shift the below items from `PipelineStepExtractor.java` to `DeclarativeSteps.java`.
 - **Functions**: `generateDeclarativeAscii`, `processDescriptors`, `getDeclarativeDirectives`, `getDeclarativeFilters` 
 - **Class Variables**: `blockedOptionSteps`, `blockedOptionStepContexts`

- [x] Organize imports in the both the classes.

Tagging the mentors: @kwhetstone @arpoch