### PR TITLE
Move parameter data types to the top

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -106,7 +106,7 @@ public class ToAsciiDoc {
         }
         return typeInfo.toString();
     }
-    
+
     private static String describeErrorType(ParameterType type) {
         return StringEscapeUtils.escapeHtml(type.getActualType().toString());
     }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -114,15 +114,18 @@ public class ToAsciiDoc {
     private static String generateAttrHelp(DescribableParameter param) throws Exception {
         StringBuilder attrHelp = new StringBuilder();
         String help = param.getHelp();
+        if (help != null && !help.equals("")) {
+            attrHelp.append(helpify(help)).append("\n");
+        }
         try {
-            if (help != null && !help.equals("")) {
-                attrHelp.append(helpify(help)).append("\n");
-            }
             String typeDesc;
-            ParameterType type = param.getType();
-            if (!(type instanceof AtomicType)) {
-                typeDesc = describeType(param.getType(), "");
-                attrHelp.append("<ul>").append(typeDesc).append("</ul>");
+            String rawTypeDesc = typeDescriptions.get(param.getRawType().getTypeName());
+            if (rawTypeDesc == null) {
+                ParameterType type = param.getType();
+                if (!(type instanceof AtomicType)) {
+                    typeDesc = describeType(type, "");
+                    attrHelp.append("<ul>").append(typeDesc).append("</ul>");
+                }
             }
         } catch (RuntimeException | Error ex) {
             LOG.log(Level.WARNING, "Restricted description of attribute "


### PR DESCRIPTION
This PR moves the data types associated with each parameter (or further nested choices) to the top where the title of each is mentioned. This will allow users to view the data types without having to click the expand button or scroll through the help content.

The imports are organized so that there are no conflicts after merging #177.

Tagging the mentors: @kwhetstone @arpoch