### PR TITLE
Use new version of pipeline-metadata-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.jenkins-ci.infra</groupId>
       <artifactId>pipeline-metadata-utils</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Use version 1.5 of pipeline-metadata-utils to check if the AsciiDocs getting generated now have all the plugins listed. 