### PR TITLE
Separate configured params to new asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ The parameters that need to be separated to new pages can be entered in `config.
 
 * Maintain the order of the parameters such that if one parameter occurs inside the nesting of another, it is written above the other in the configuration file. For example, `$class: 'GitSCM'` is present inside `$class: MultiSCM` in checkout step, hence, it must be written above in the configuration file.
 
-* A parameter must have atleast 100 lines of asciidoc code present in the location from which it is supposed to be removed.
+* A parameter must have at least 100 lines of asciidoc code present in the location from which it is supposed to be removed.

--- a/README.md
+++ b/README.md
@@ -113,3 +113,13 @@ make -C ../jenkins.io run
 ```
 
 You can then browse to [Pipeline Steps Reference](http://localhost:4242/doc/pipeline/steps/) to see the running instance of `jenkins.io` on your `localhost`.
+
+### 6. Configure Parameters
+
+The parameters that need to be separated to new pages can be entered in `config.txt` by adhering to the following rules. This feature reduces the content on longer pages, thus increasing the loading speed of these pages.
+
+* Ensure that a specified parameter's documentation is the same everywhere it occurs in the Pipeline Steps Reference. For example, `perforce` contains different documentation under the checkout step's scm parameter and the scanForIssues step's tool parameter. Hence, it can not be included in the configuration file.
+
+* Maintain the order of the parameters such that if one parameter occurs inside the nesting of another, it is written above the other in the configuration file. For example, `$class: 'GitSCM'` is present inside `$class: MultiSCM` in checkout step, hence, it must be written above in the configuration file.
+
+* A parameter must have atleast 100 lines of asciidoc code present in the location from which it is supposed to be removed.

--- a/config.txt
+++ b/config.txt
@@ -1,0 +1,42 @@
+-- Add a single line comment by starting with "--"
+
+-- parameter classes that occur under scm
+-- (all these classes have same documentation present at 10 different places)
+$class: 'CCUCMScm'
+$class: 'CVSSCM'
+$class: 'CvsProjectset'
+$class: 'GitSCM'
+$class: 'MercurialSCM'
+$class: 'RTCScm'
+$class: 'SubversionSCM'
+$class: 'hudson.plugins.repo.RepoScm'
+$class: 'MultiSCM'
+
+-- only present in workflow-multibranch.adoc
+$class: 'JobRestrictionProperty'
+pipelineTriggers
+$class: 'YouTrackProjectProperty'
+$class: 'it.dockins.dockerslaves.spec.ContainerSetDefinition'
+
+-- common for workflow-multibranch.adoc, hubot-steps.adoc, pipeline-input-step.adoc
+$class: 'ExtensibleChoiceParameterDefinition'
+$class: 'RunFilterParameter'
+$class: 'RunSelectorParameter'
+
+-- common for workflow-multibranch.adoc, pipeline-groovy-lib.adoc
+$class: 'BacklogPullRequestSCMSource'
+multiBranch
+dagshubScmSource
+gitblit
+git
+$class: 'GiteaSCMSource'
+multiGraph
+$class: 'MercurialSCMSource'
+scmManager
+scmManagerSvn
+fromScm
+multiStreams
+$class: 'SubversionSCMSource'
+multiSwarm
+Tuleap
+bitbucket

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -21,8 +21,8 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.jenkinsci.infra.tools.HyperLocalPluginManager;
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.infra.tools.HyperLocalPluginManager;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableParameter;
 import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType;
@@ -259,6 +259,9 @@ public class PipelineStepExtractor {
                 //continue to next plugin
             }
         }
+        ProcessAsciiDoc pad = new ProcessAsciiDoc();
+        new File(allAsciiPath + "/params").mkdirs();
+        pad.processDocs(allAsciiPath, 100);
     }
 
     public void generateDeclarativeSteps() {

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
@@ -1,0 +1,125 @@
+package org.jenkinsci.pipeline_steps_doc_generator;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * Acts as a processing layer after the AsciiDocs are generated from
+ * {@link ToAsciiDoc}.
+ * It removes redundancy of the configured parameter class names, by creating a
+ * global document of the class that all Pipeline steps can refer to.
+ */
+public class ProcessAsciiDoc {
+
+    private static final Logger LOG = Logger.getLogger(ProcessAsciiDoc.class.getName());
+
+    public void generateHeader(StringBuilder toWrite, String className) {
+        toWrite.append("---\nlayout: pipelinesteps\ntitle: \"").append(className)
+                .append("\"\n---\n")
+                .append("== " + className + "\n")
+                .append("\n++++\n");
+    }
+
+    /**
+     * Takes in a Pipeline step parameter's class name, and separates its
+     * documentation on to a new file.
+     */
+    public String separateClass(String className, String allAscii, File child, int linesThreshold)
+            throws IOException, RuntimeException {
+        BufferedReader br = new BufferedReader(new FileReader(child));
+        StringBuilder duplicate = new StringBuilder(); // contains the content of the current file minus the parameter
+                                                       // details
+        String line;
+        int counter = 0; // keeps a count of opening and closing li tags to mark the end of a section
+        boolean flag = false;
+        int lines = 0;
+        String url = className.toLowerCase().replaceAll("class", "").replaceAll("[^a-zA-Z0-9]", "");
+        Path adocPath = Path.of(allAscii + "/params/" + url + ".adoc"); // points to the params folder that will contain
+                                                                        // the separated files
+        StringBuilder newAdoc = new StringBuilder(); // new file that contains only the parameter details
+        generateHeader(newAdoc, className);
+        try {
+            while ((line = br.readLine()) != null) {
+                if (!flag && line.contains("<li><code>" + className + "</code><div>")) {
+                    flag = true;
+                    duplicate.append("<li><span><a href=\"/doc/pipeline/steps/params/" + url
+                            + "\" target=\"_blank\"><code>" + className + "</code></a></span></li>\n");
+                } else if (!flag) {
+                    duplicate.append(line).append("\n");
+                }
+                if (flag) {
+                    counter += (line.split("<li>", -1).length - line.split("</li>", -1).length);
+                    lines++;
+                    if (newAdoc != null)
+                        newAdoc.append(line).append("\n");
+                    if (counter == 0) {
+                        if (newAdoc != null) {
+                            if (lines < linesThreshold) {
+                                throw new RuntimeException("Invalid Configuration, " + className
+                                        + " does not have sufficient documentation to be separated!");
+                                // halt the program if any of the configured parameters does not contain
+                                // sufficient documentation
+                            }
+                            newAdoc.append("\n\n++++");
+                            Files.writeString(adocPath, newAdoc.toString());
+                            newAdoc = null;
+                        }
+                        lines = 0;
+                        flag = false;
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            br.close();
+        }
+        return duplicate.toString();
+    }
+
+    /**
+     * Note that the method exits when the configuration file does not follow the
+     * suggested conventions.
+     * Please refer to the README while troubleshooting.
+     * 
+     * @param allAscii path to the directory containing all the AsciiDocs.
+     * @throws RuntimeException thrown if a configured class lacks sufficient
+     *                          documentation.
+     * @throws IOException
+     */
+    public void processDocs(String allAscii, int linesThreshold) {
+        File dir = new File(allAscii);
+        File[] directoryListing = dir.listFiles();
+        LOG.info("processing the generated asciidocs...");
+        try {
+            List<String> config = Files.readAllLines(Paths.get("config.txt"));
+            for (String className : config) {
+                className = className.trim();
+                if (className.startsWith("--") || className.isBlank()) {
+                    continue;
+                }
+                LOG.info("Iterating through parameter class name: " + className);
+                if (directoryListing != null) {
+                    for (File child : directoryListing) {
+                        String type = FilenameUtils.getExtension(child.getName());
+                        if (type.equals("adoc")) {
+                            Path currentPath = Path.of(child.getPath());
+                            Files.writeString(currentPath, separateClass(className, allAscii, child, linesThreshold));
+                        }
+                    }
+                }
+            }
+        } catch (IOException | RuntimeException ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.pipeline_steps_doc_generator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+public class ProcessAsciiDocTest {
+    String allAscii = "src/test/resources/input/";
+    File child = new File(allAscii + "/workflow-scm.adoc");
+
+    @Test
+    public void isExceptionThrown() {
+        ProcessAsciiDoc pad = new ProcessAsciiDoc();
+        try {
+            pad.separateClass("$class: 'PvcsScm'", allAscii, child, 500);
+            assertTrue(false);
+        } catch (RuntimeException ex) {
+            assertTrue(true);
+        } catch (IOException ex) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void isNewAdocCreated() {
+        ProcessAsciiDoc pad = new ProcessAsciiDoc();
+        try {
+            pad.separateClass("$class: 'GitSCM'", allAscii, child, 500);
+            File file = new File("src/test/resources/input/params/gitscm.adoc");
+            assertTrue(file.exists());
+            file.delete();
+        } catch (RuntimeException | IOException ex) {
+            ex.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void isSeparatedContentCorrect() {
+        ProcessAsciiDoc pad = new ProcessAsciiDoc();
+        try {
+            pad.separateClass("$class: 'GitSCM'", allAscii, child, 500);
+            File file1 = new File("src/test/resources/input/params/gitscm.adoc");
+            File file2 = new File("src/test/resources/input/compare/gitscm.adoc");
+            assertTrue(FileUtils.contentEquals(file1, file2));
+            file1.delete();
+        } catch (RuntimeException | IOException ex) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void isHyperlinkReplacedCorrectly() {
+        ProcessAsciiDoc pad = new ProcessAsciiDoc();
+        try {
+            String[] lines = pad.separateClass("$class: 'GitSCM'", allAscii, child, 500).split("\n");
+            String link = "";
+            File file = new File("src/test/resources/input/params/gitscm.adoc");
+            file.delete();
+            for (String line : lines) {
+                if (line.contains("class: 'GitSCM'")) {
+                    link = line;
+                    break;
+                }
+            }
+            assertEquals(
+                    "<li><span><a href=\"/doc/pipeline/steps/params/gitscm\" target=\"_blank\"><code>$class: 'GitSCM'</code></a></span></li>",
+                    link);
+        } catch (RuntimeException | IOException ex) {
+            assertTrue(false);
+        }
+    }
+}

--- a/src/test/resources/input/compare/gitscm.adoc
+++ b/src/test/resources/input/compare/gitscm.adoc
@@ -1,0 +1,844 @@
+---
+layout: pipelinesteps
+title: "$class: 'GitSCM'"
+---
+== $class: 'GitSCM'
+
+++++
+<li><code>$class: 'GitSCM'</code><div>
+<div><div>
+ <p>The <a href="https://plugins.jenkins.io/git/" rel="nofollow">git plugin</a> provides fundamental git operations for Jenkins projects. It can poll, fetch, checkout, and merge contents of git repositories.</p>
+ <p>The git plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step" rel="nofollow"><code>checkout</code></a> step. The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator" rel="nofollow"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.</p>
+</div></div>
+<ul><li><code>userRemoteConfigs</code>
+<div><div>
+ Specify the repository to track. This can be a URL or a local file path. Note that for super-projects (repositories with submodules), only a local file path or a complete URL is valid. The following are examples of valid git URLs. 
+ <ul>
+  <li>ssh://git@github.com/github/git.git</li>
+  <li>git@github.com:github/git.git (short notation for ssh protocol)</li>
+  <li>ssh://user@other.host.com/~/repos/R.git (to access the repos/R.git repository in the user's home directory)</li>
+  <li>https://github.com/github/git.git</li>
+ </ul> <br> If the repository is a super-project, the location from which to clone submodules is dependent on whether the repository is bare or non-bare (i.e. has a working directory). 
+ <ul>
+  <li>If the super-project is bare, the location of the submodules will be taken from <em>.gitmodules</em>.</li>
+  <li>If the super-project is <strong>not</strong> bare, it is assumed that the repository has each of its submodules cloned and checked out appropriately. Thus, the submodules will be taken directly from a path like <code>${SUPER_PROJECT_URL}/${SUBMODULE}</code>, rather than relying on information from <em>.gitmodules</em>.</li>
+ </ul> For a local URL/path to a super-project, <em>git rev-parse --is-bare-repository</em> is used to detect whether the super-project is bare or not. <br> For a remote URL to a super-project, the ending of the URL determines whether a bare or non-bare repository is assumed: 
+ <ul>
+  <li>If the remote URL ends with <em>/.git</em>, a <em>non</em>-bare repository is assumed.</li>
+  <li>If the remote URL does <strong>NOT</strong> end with <em>/.git</em>, a bare repository is assumed.</li>
+ </ul>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>url : String</code>
+<div><div>
+ Specify the URL or path of the git repository. This uses the same syntax as your <code>git clone</code> command.
+</div></div>
+
+</li>
+<li><code>name : String</code>
+<div><div>
+ ID of the repository, such as <code>origin</code>, to uniquely identify this repository among other remote repositories. This is the same "name" that you use in your <code>git remote</code> command. If left empty, Jenkins will generate unique names for you. 
+ <p>You normally want to specify this when you have multiple remote repositories.</p>
+</div></div>
+
+</li>
+<li><code>refspec : String</code>
+<div><div>
+ A refspec controls the remote refs to be retrieved and how they map to local refs. If left blank, it will default to the normal behaviour of <code>git fetch</code>, which retrieves all the branch heads as <code>remotes/REPOSITORYNAME/BRANCHNAME</code>. This default behaviour is OK for most cases. 
+ <p>In other words, the default refspec is "+refs/heads/*:refs/remotes/REPOSITORYNAME/*" where <code>REPOSITORYNAME</code> is the value you specify in the above "name of repository" textbox.</p>
+ <p>When do you want to modify this value? A good example is when you want to just retrieve one branch. For example, <code>+refs/heads/master:refs/remotes/origin/master</code> would only retrieve the master branch and nothing else.</p>
+ <p>The plugin uses a default refspec for its initial fetch, unless the "Advanced Clone Option" is set to honor refspec. This keeps compatibility with previous behavior, and allows the job definition to decide if the refspec should be honored on initial clone.</p>
+ <p>Multiple refspecs can be entered by separating them with a space character. <code>+refs/heads/master:refs/remotes/origin/master&nbsp;+refs/heads/develop:refs/remotes/origin/develop</code> retrieves the master branch and the develop branch and nothing else.</p>
+ <p>See <a href="https://git-scm.com/book/en/v2/Git-Internals-The-Refspec" rel="nofollow">the refspec definition in Git user manual</a> for more details.</p>
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ Credential used to <strong>check out</strong> sources.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>branches</code>
+<div><div>
+ List of branches to build. Jenkins jobs are most effective when each job builds only a single branch. When a single job builds multiple branches, the changelog comparisons between branches often show no changes or incorrect changes.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+<div><div>
+ <p>Specify the branches if you'd like to track a specific branch in a repository. If left blank, all branches will be examined for changes and built.</p>
+ <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch is unambiguous.</p>
+ <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented with a full path the plugin will only use the part of the string right of the last slash. Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+ <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>), you'll need to specify the origin repository in the branch names to make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+ <p>Possible options:</p>
+ <ul>
+  <li><strong><code>&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>master</code>, <code>feature1</code>, ...</li>
+  <li><strong><code>refs/heads/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...</li>
+  <li><strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one.<br> Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>origin/master</code></li>
+  <li><strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>remotes/origin/master</code></li>
+  <li><strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/remotes/origin/master</code></li>
+  <li><strong><code>&lt;tagName&gt;</code></strong><br> This does not work since the tag will not be recognized as tag.<br> Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br> E.g. <code>git-2.3.0</code></li>
+  <li><strong><code>refs/tags/&lt;tagName&gt;</code></strong><br> Tracks/checks out the specified tag.<br> E.g. <code>refs/tags/git-2.3.0</code></li>
+  <li><strong><code>&lt;commitId&gt;</code></strong><br> Checks out the specified commit.<br> E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...</li>
+  <li><strong><code>${ENV_VARIABLE}</code></strong><br> It is also possible to use environment variables. In this case the variables are evaluated and the result is used as described above.<br> E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...</li>
+  <li><strong><code>&lt;Wildcards&gt;</code></strong><br> The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>. In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.</li>
+  <li><strong><code>:&lt;regular expression&gt;</code></strong><br> The syntax is of the form: <code>:regexp</code>. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.<br> Examples:<br>
+   <ul>
+    <li><code>:^(?!(origin/prefix)).*</code>
+     <ul>
+      <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+      <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+     </ul></li>
+    <li><code>:origin/release-\d{8}</code>
+     <ul>
+      <li>matches: <code>origin/release-20150101</code></li>
+      <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+     </ul></li>
+    <li><code>:^(?!origin/master$|origin/develop$).*</code>
+     <ul>
+      <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+      <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+     </ul></li>
+   </ul></li>
+ </ul>
+ <p></p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>browser</code>
+<div><div>
+ Defines the repository browser that displays changes detected by the git plugin.
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AssemblaWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://www.assembla.com/code/PROJECT/git/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BacklogGitRepositoryBrowser'</code><div>
+<ul><li><code>repoName : String</code>
+</li>
+<li><code>repoUrl : String</code>
+</li>
+</ul></div></li>
+<li><code>bitbucketServer</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the Bitbucket Server root URL for this repository (such as <em>https://bitbucket:7990/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BitbucketWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://bitbucket.org/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://cgit.example.com:port/group/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'FisheyeGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the URL of this repository in FishEye (such as <em>http://fisheye6.cenqua.com/browse/ant/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBlitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository.
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in GitBlit.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBucketBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLab'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlabserver:port/group/REPO/</em>).
+</div></div>
+
+</li>
+<li><code>version : String</code> (optional)
+<div><div>
+ Specify the major and minor version of GitLab you use (such as 9.1). If you don't specify a version, a modern version of GitLab (&gt;= 8.0) is assumed.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLabBrowser'</code><div>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page so that links to changes can be automatically generated by Jenkins. The URL needs to include the owner and project. If the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>.
+</div></div>
+<ul><li><code>projectUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page. The URL needs to include the owner and project so, for example, if the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitList'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlistserver:port/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://github.com/jenkinsci/jenkins.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GiteaBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Gitea page. The URL needs to include the owner and repository so, for example, if the Gitea server is <code>https://gitea.example.com</code> then the URL for bob's skunkworks project repository might be <code>https://gitea.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GithubWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's GitHub page (such as <em>https://github.com/jquery/jquery</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Gitiles'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gwt.googlesource.com/gwt/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitoriousWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gitorious.org/gitorious/mainline</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GogsGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gogs.example.com:port/username/some-repo-url.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://khanacademy.kilnhg.com/Code/Website/Group/webapp</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Phabricator'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the phabricator instance root URL (such as <em>http://phabricator.example.com</em>).
+</div></div>
+
+</li>
+<li><code>repo : String</code>
+<div><div>
+ Specify the repository name in phabricator (such as the <em>foo</em> part of <em>phabricator.example.com/diffusion/foo/browse</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RedmineWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://SERVER/PATH/projects/PROJECT/repository</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's RhodeCode page (such as <em>http://rhodecode.mydomain.com:5000/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManagerGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://scm-manager.org/scm/repo/namespace/name</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Stash'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Stash page (such as <em>http://stash.mydomain.com:7990/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TFS2013GitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Either the name of the remote whose URL should be used, or the URL of this module in TFS (such as <em>http://fisheye6.cenqua.com/tfs/PROJECT/_git/REPO/</em>). If empty (default), the URL of the "origin" repository is used. 
+ <p>If TFS is also used as the repository server, this can usually be left blank.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TracGitRepositoryBrowser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TuleapBrowser'</code><div>
+<div><div>
+ Specify the HTTPS URL for the Tuleap Git repository so that links to changes can be automatically generated by Jenkins.
+</div></div>
+<ul><li><code>repositoryUrl : String</code>
+<div><div>
+ The URL is the web URL of the Tuleap Git repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewGitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in ViewGit (e.g. scripts, scuttle etc. from <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>gitTool : String</code>
+<div><p>Absolute path to the git executable.</p>
+<p>This is <strong>different</strong> from other Jenkins tool definitions. Rather than providing the directory that contains the executable, you <strong>must provide the complete path to the executable</strong>. Setting '<code>/usr/bin/git</code>' would be correct, while setting '<code>/usr/bin/</code>' is not correct.</p></div>
+
+</li>
+<li><code>extensions</code>
+<div><div>
+ <p>Extensions add new behavior or modify existing plugin behavior for different uses. Extensions help users more precisely tune plugin behavior to meet their needs.</p>
+ <p>Extensions include:</p>
+ <ul>
+  <li><strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace. The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.</li>
+  <li><strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent. The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.</li>
+  <li><strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.</li>
+  <li><strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.</li>
+  <li><strong>Build initiation extensions</strong> control the conditions that start a build. They can ignore notifications of a change or force a deeper evaluation of the commits when polling.</li>
+  <li><strong>Merge extensions</strong> can optionally merge changes from other branches into the current branch of the agent workspace. They control the source branch for the merge and the options applied to the merge.</li>
+ </ul>
+ <p></p>
+</div></div>
+
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AuthorInChangelog'</code><div>
+<div><div>
+ The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets. If this option is selected, the Git commit's "Author" value would be used instead.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'BuildChooserSetting'</code><div>
+<div><div>
+ When you are interested in using a job to build multiple heads (most typically multiple branches), you can choose how Jenkins choose what branches to build in what order. 
+ <p>This extension point in Jenkins is used by many other plugins to control the job to build specific commits. When you activate those plugins, you may see them installing a custom strategy here.</p>
+</div></div>
+<ul><li><code>buildChooser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AlternativeBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'AncestryBuildChooser'</code><div>
+<ul><li><code>maximumAgeInDays : int</code>
+</li>
+<li><code>ancestorCommitSha1 : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DefaultBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'DeflakeGitBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GerritTriggerBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'InverseBuildChooser'</code><div>
+<ul></ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'BuildSingleRevisionOnly'</code><div>
+<div><div>
+ Disable scheduling for multiple candidate revisions.<br> If we have 3 branches:<br> ----A--.---.--- B<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br> jenkins would try to build (B) and (C).<br> This behaviour disables this and only builds one of them.<br> It is helpful to reduce the load of the Jenkins infrastructure when the SCM system like Bitbucket or GitHub should decide what commits to build.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ChangelogToBranch'</code><div>
+<div><div>
+ This method calculates the changelog against the specified branch.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>compareRemote : String</code>
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below.
+</div></div>
+
+</li>
+<li><code>compareTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to compare against.
+</div></div>
+
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CheckoutOption'</code><div>
+<ul><li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for checkout.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanBeforeCheckout'</code><div>
+<div><div>
+ Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanCheckout'</code><div>
+<div><div>
+ Clean up the workspace after every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneOption'</code><div>
+<ul><li><code>shallow : boolean</code>
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code>
+<div><div>
+ Deselect this to perform a clone without tags, saving time and disk space when you just want to access what is specified by the refspec.
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for clone and fetch operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>honorRefspec : boolean</code> (optional)
+<div><div>
+ Perform initial clone using the refspec defined for the repository. This can save time, data transfer and disk space when you only need to access the references specified by the refspec.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CodeCommitURLHelper'</code><div>
+<ul><li><code>credentialId : String</code>
+<div><div>
+ <p>OPTIONAL: Select the credentials to use.<br> If not specified, defaults to the <a href="http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain" rel="nofollow"> DefaultAWSCredentialsProviderChain </a> behaviour - <b>*FROM THE JENKINS INSTANCE*</b></p>
+ <p>In the latter case, usage of IAM Role Profiles seems not to work, thus relying on environment variables / system properties or the ~/.aws/credentials file, thus not recommended.</p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DisableRemotePoll'</code><div>
+<div><div>
+ Git plugin uses git ls-remote polling mechanism by default when configured with a single branch (no wildcards!). This compare the latest built commit SHA with the remote branch without cloning a local copy of the repo.<br><br> If you don't want to / can't use this.<br><br> If this option is selected, polling will require a workspace and might trigger unwanted builds (see <a href="https://issues.jenkins.io/browse/JENKINS-10131" rel="nofollow">JENKINS-10131</a>).
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromChangeSet'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromPoll'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GitLFSPull'</code><div>
+<div><div>
+ Enable <a href="https://git-lfs.github.com/" rel="nofollow">git large file support</a> for the workspace by pulling large files after the checkout completes. Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'GitSCMChecksExtension'</code><div>
+<ul><li><code>verboseConsoleLog : boolean</code> (optional)
+<div><div>
+ If this option is checked, verbose log will be output to build console; the verbose log is useful for debugging the publisher creation.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCMStatusChecksExtension'</code><div>
+<ul><li><code>name : String</code> (optional)
+</li>
+<li><code>skip : boolean</code> (optional)
+</li>
+<li><code>skipProgressUpdates : boolean</code> (optional)
+</li>
+<li><code>suppressLogs : boolean</code> (optional)
+</li>
+<li><code>unstableBuildNeutral : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'GitTagMessageExtension'</code><div>
+<div><div>
+ If the revision checked out has a git tag associated with it, the tag name will be exported during the build as <strong>GIT_TAG_NAME</strong>. <br> If a message was specified when creating the tag, then that message will be exported during the build as the <strong>GIT_TAG_MESSAGE</strong> environment variable. <br> If no tag message was specified, the commit message will be used. <br> If you ticked the <strong>Use most recent tag</strong> option, and the revision checked out has no git tag associated with it, the parent commits will be searched for a git tag, and the rules stated above will apply to the first parent commit with a git tag. 
+ <p></p> If the revision has more than one tag associated with it, only the most recent tag will be taken into account, <strong>unless</strong> the refspec contains "refs/tags/" — i.e. builds are only triggered when certain tag names or patterns are matched — in which case the exact tag name that triggered the build will be used, even if it's not the most recent tag for this commit. <br> For this reason, if you're not using a tag-specific refspec but you <em>are</em> using the "Create a tag for every build" behaviour, you should make sure that the build-tagging behaviour is configured to run <em>after</em> this "export git tag message" behaviour. 
+ <p></p> Tag and commit messages which span multiple lines are no problem, though only the first 10000 lines of a tag's message will be exported.
+</div></div>
+<ul><li><code>useMostRecentTag : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IgnoreNotifyCommit'</code><div>
+<div><div>
+ If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository matches or not.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'LocalBranch'</code><div>
+<div><div>
+ If given, checkout the revision to build as HEAD on this branch. 
+ <p>If selected, and its value is an empty string or "**", then the branch name is computed from the remote branch without the origin. In that case, a remote branch origin/master will be checked out to a local branch named master, and a remote branch origin/develop/new-feature will be checked out to a local branch named develop/newfeature.</p>
+ <p>Please note that this has not been tested with submodules.</p>
+</div></div>
+<ul><li><code>localBranch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MessageExclusion'</code><div>
+<ul><li><code>excludedMessage : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct message. 
+ <p></p>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()" rel="nofollow">matching</a>
+ <p></p>
+ <pre>.*\[maven-release-plugin\].*</pre> The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have been committed to the SCM a build will not occur. 
+ <p></p> You can create more complex patterns using embedded flag expressions. 
+ <pre>(?s).*FOO.*</pre> This example will search FOO message in all comment lines.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PathRestriction'</code><div>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
+</div></div>
+<ul><li><code>includedRegions : String</code>
+<div><div>
+ Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. An empty list implies that everything is included. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that a build will only occur, if html/jpeg/gif files have been committed to the SCM. Exclusions take precedence over inclusions, if there is an overlap between included and excluded regions.
+</div></div>
+
+</li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PerBuildTag'</code><div>
+<div><div>
+ Create a tag in the workspace for every build to unambiguously mark the commit that was built. You can combine this with Git publisher to push the tags to the remote repository.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'PreBuildMerge'</code><div>
+<div><div>
+ These options allow you to perform a merge to a particular branch before building. For example, you could specify an integration branch to be built, and to merge to master. In this scenario, on every change of integration, Jenkins will perform a merge with the master branch, and try to perform a build if the merge is successful. It then may push the merge back to the remote repository if the Git Push post-build action is selected.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>mergeTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to merge to, such as <code>master</code>.
+</div></div>
+
+</li>
+<li><code>fastForwardMode</code> (optional)
+<div><div>
+ Merge fast-forward mode selection.<br> The default, --ff, gracefully falls back to a merge commit when required.<br> For more information, see the <a href="http://git-scm.com/docs/git-merge" rel="nofollow">Git Merge Documentation</a>
+</div></div>
+
+<ul><li><b>Values:</b> <code>FF</code>, <code>FF_ONLY</code>, <code>NO_FF</code></li></ul></li>
+<li><code>mergeRemote : String</code> (optional)
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below. If left blank, it'll default to the name of the first repository configured above.
+</div></div>
+
+</li>
+<li><code>mergeStrategy</code> (optional)
+<div><div>
+ Merge strategy selection. <strong>This feature is not fully implemented in JGIT.</strong>
+</div></div>
+
+<ul><li><b>Values:</b> <code>DEFAULT</code>, <code>RESOLVE</code>, <code>RECURSIVE</code>, <code>OCTOPUS</code>, <code>OURS</code>, <code>SUBTREE</code>, <code>RECURSIVE_THEIRS</code></li></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>pretestedIntegration</code><div>
+<ul><li><code>gitIntegrationStrategy</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>accumulated</code><div>
+<div><h2>Accumulated Commit Strategy</h2>
+<div>
+ This strategy merges your commits with the --no-ff switch
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>ffonly</code><div>
+<div><h2>Fast Forward only (--ff-only) Strategy</h2>
+<div>
+ This strategy fast-forward only using the --ff-only switch - or fails
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>squash</code><div>
+<div><h2>Squashed Commit Strategy</h2>
+<div>
+ This strategy squashes all your commit on a given branch with the --squash option
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>integrationBranch : String</code>
+<div><h3>What to specify</h3>
+<p>The branch name must match your integration branch name. <b>No trailing slash.</b></p>
+<h3>Merge is performed the following way</h3>
+<h5>Squash commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge --squash &lt;Branch matched by git&gt;
+            git commit -C &lt;Branch matched by git&gt;</pre>
+<h5>Accumulated commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge -m &lt;commitMsg&gt; &lt;Branch matched by git&gt; --no-ff</pre>
+<h3>When changes are pushed to the integration branch?</h3>
+<p>Changes are only ever pushed when the build results is SUCCESS</p>
+<pre>            git push &lt;Repository name&gt; &lt;Branch name&gt;</pre></div>
+
+</li>
+<li><code>repoName : String</code>
+<div><div>
+ <h3>What to specify</h3>
+ <p>The repository name. In git the repository is always the name of the remote. So if you have specified a repository name in your Git configuration. You need to specify the exact same name here, otherwise no integration will be performed. We do the merge based on this.</p>
+ <p><b>No trailing slash on repository name.</b></p>
+ <p><span>Remember to specify this when working with NAMED repositories in Git</span></p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PruneStaleBranch'</code><div>
+<div><div>
+ Run "git remote prune" for each remote, to prune obsolete local branches.
+</div></div>
+<ul></ul></div></li>
+<li><code>pruneTags</code><div>
+<ul><li><code>pruneTags : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RelativeTargetDirectory'</code><div>
+<ul><li><code>relativeTargetDir : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where the Git repository will be checked out. If left empty, the workspace root itself will be used. 
+ <p>This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted). Jenkins Pipeline already provides standard techniques for checkout to a subdirectory. Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" rel="nofollow">ws</a> and <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" rel="nofollow">dir</a> in Jenkins Pipeline rather than this extension.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmName'</code><div>
+<div><div>
+ <p>Unique name for this SCM. Needed when using Git within the Multi SCM plugin.</p>
+</div></div>
+<ul><li><code>name : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SparseCheckoutPaths'</code><div>
+<div><div>
+ <p>Specify the paths that you'd like to sparse checkout. This may be used for saving space (Think about a reference repository). Be sure to use a recent version of Git, at least above 1.7.10</p>
+</div></div>
+<ul><li><code>sparseCheckoutPaths</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>path : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'SubmoduleOption'</code><div>
+<ul><li><code>disableSubmodules : boolean</code>
+<div><div>
+ By disabling support for submodules you can still keep using basic git plugin functionality and just have Jenkins to ignore submodules completely as if they didn't exist.
+</div></div>
+
+</li>
+<li><code>recursiveSubmodules : boolean</code>
+<div><div>
+ Retrieve all submodules recursively (uses '--recursive' option which requires git&gt;=1.6.5)
+</div></div>
+
+</li>
+<li><code>trackingSubmodules : boolean</code>
+<div><div>
+ Retrieve the tip of the configured branch in .gitmodules (Uses '--remote' option which requires git&gt;=1.8.2)
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.<br> To prepare a reference folder with multiple subprojects, create a bare git repository and add all the remote urls then perform a fetch:<br>
+ <pre>  git init --bare
+  git remote add SubProject1 https://gitrepo.com/subproject1
+  git remote add SubProject2 https://gitrepo.com/subproject2
+  git fetch --all
+  </pre>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for submodules operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>parentCredentials : boolean</code>
+<div><div>
+ Use credentials from the default remote of the parent project.
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>shallow : boolean</code> (optional)
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>threads : int</code> (optional)
+<div><div>
+ Specify the number of threads that will be used to update submodules.<br> If unspecified, the command line git default thread count is used.<br>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserExclusion'</code><div>
+<ul><li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well. 
+ <p></p>Each exclusion uses exact string comparison and must be separated by a new line. User names are only excluded if they exactly match one of the names in this list. 
+ <p></p>
+ <pre>auto_build_user</pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserIdentity'</code><div>
+<ul><li><code>name : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+<li><code>email : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WipeWorkspace'</code><div>
+<div><div>
+ Delete the contents of the workspace before building, ensuring a fully fresh workspace.
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>doGenerateSubmoduleConfigurations : boolean</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value and always uses <code>false</code> as its value.</p></div>
+
+</li>
+<li><code>submoduleCfg</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value(s) and always uses empty values.</p></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>submoduleName : String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+</li>
+<li><code>branches : Array / List of String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+<ul></ul></li>
+</ul></li>
+</ul></div></li>
+
+
+++++

--- a/src/test/resources/input/workflow-scm.adoc
+++ b/src/test/resources/input/workflow-scm.adoc
@@ -1,0 +1,8649 @@
+---
+layout: pipelinesteps
+title: "Pipeline: SCM Step"
+---
+
+:notitle:
+:description:
+:author:
+:email: jenkinsci-users@googlegroups.com
+:sectanchors:
+:toc: left
+:compat-mode!:
+
+== Pipeline: SCM Step
+
+plugin:workflow-scm-step[View this plugin on the Plugins site]
+
+=== `checkout`: Check out from version control
+++++
+<ul><li><code>scm</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AWSCodePipelineSCM'</code><div>
+<ul><li><code>name : String</code>
+</li>
+<li><code>clearWorkspace : boolean</code>
+</li>
+<li><code>region : String</code>
+</li>
+<li><code>awsAccessKey : String</code>
+<div><div>
+ <p>In order to integrate with AWS CodePipeline, you must authorize access to the pipeline and its related artifacts. If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials. This is the preferred method. In all other cases, you can store AWS credentials in these fields. You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted. For more information, see <a rel="nofollow">AWS CodePipeline Integration for Other Products and Services</a>.</p>
+</div></div>
+
+</li>
+<li><code>awsSecretKey : String</code>
+<div><div>
+ <p>&gt;In order to integrate with AWS CodePipeline, you must authorize access to the pipeline and its related artifacts. If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials. This is the preferred method. In all other cases, you can store AWS credentials in these fields. You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted. For more information, see <a rel="nofollow">AWS CodePipeline Integration for Other Products and Services</a>.</p>
+</div></div>
+
+</li>
+<li><code>proxyHost : String</code>
+<div><div>
+ <p>You might need a proxy host address if you are hosting Jenkins on a private network. The proxy name can be an IP address or DNS address. The AWS CodePipeline Plugin for Jenkins requires internet access. If access is not configured, you might see errors in the AWS CodePipeline Polling Log.</p>
+</div></div>
+
+</li>
+<li><code>proxyPort : String</code>
+<div><div>
+ <p>You might need a proxy port for your proxy host address if you are hosting Jenkins on a private network. The proxy port is a number, might be on port 8080, 3128, or 8443, depending on your network protocols and security settings. If access is not configured, you might see errors in the AWS CodePipeline Polling Log.</p>
+</div></div>
+
+</li>
+<li><code>category : String</code>
+<div><div>
+ <p>This is the category of the action type in AWS CodePipeline, and is usually either Build or Test. To see an example usage, see <a rel="nofollow">Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+</div></div>
+
+</li>
+<li><code>provider : String</code>
+<div><div>
+ <p>This is the provider name of the action type in AWS CodePipeline. You must provide this exact string when adding an action for Jenkins in AWS CodePipeline. To see an example usage, see <a rel="nofollow">Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+</div></div>
+
+</li>
+<li><code>version : String</code>
+<div><div>
+ <p>Leave the default as 1.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>accurev</code><div>
+<ul><li><code>depot : String</code>
+</li>
+<li><code>stream : String</code>
+</li>
+<li><code>serverName : String</code> (optional)
+</li>
+<li><code>serverUUID : String</code> (optional)
+</li>
+<li><code>wspaceORreftree : String</code> (optional)
+</li>
+<li><code>accurevTool : String</code> (optional)
+</li>
+<li><code>cleanreftree : boolean</code> (optional)
+</li>
+<li><code>directoryOffset : String</code> (optional)
+</li>
+<li><code>dontPopContent : boolean</code> (optional)
+</li>
+<li><code>filterForPollSCM : String</code> (optional)
+</li>
+<li><code>ignoreStreamParent : boolean</code> (optional)
+</li>
+<li><code>reftree : String</code> (optional)
+</li>
+<li><code>snapshotNameFormat : String</code> (optional)
+</li>
+<li><code>subPath : String</code> (optional)
+</li>
+<li><code>subPathOnly : boolean</code> (optional)
+</li>
+<li><code>synctime : boolean</code> (optional)
+</li>
+<li><code>useSnapshot : boolean</code> (optional)
+</li>
+<li><code>workspace : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'BazaarSCM'</code><div>
+<ul><li><code>source : String</code>
+</li>
+<li><code>cleantree : boolean</code>
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'Loggerhead'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Loggerhead is a web-based interface for <a href="http://bazaar-vcs.org" rel="nofollow">Bazaar </a> branches. It is used by <a href="https://launchpad.net" rel="nofollow">Launchpad</a>, so if your code is hosted on Launchpad, you are using Loggerhead.
+</div>
+<div>
+ The repository browser URL for the root of the project. For example, a Launchpad project called myproject would use http://bazaar.launchpad.net/~myteam/myproject/mybranch.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ The repository browser URL for the root of the project. For example, the OpenGrok project would use http://src.opensolaris.org/source/.
+</div></div>
+
+</li>
+<li><code>rootModule : String</code>
+<div><div>
+ Specify the root Bazaar module that this OpenGrok monitors. For example, for http://src.opensolaris.org/source/xref/opengrok/trunk/, this field would be opengrok/trunk/ because it displays the directory "/opengrok/trunk/".
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>checkout : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'BitKeeperSCM'</code><div>
+<ul><li><code>parent : String</code>
+</li>
+<li><code>localRepository : String</code>
+</li>
+<li><code>usePull : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+</li>
+</ul></div></li>
+<li><code>BbS</code><div>
+<ul><li><code>id : String</code>
+</li>
+<li><code>branches</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+<div><div>
+ <p>Specify the branches if you'd like to track a specific branch in a repository. If left blank, all branches will be examined for changes and built.</p>
+ <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch is unambiguous.</p>
+ <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented with a full path the plugin will only use the part of the string right of the last slash. Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+ <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>), you'll need to specify the origin repository in the branch names to make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+ <p>Possible options:</p>
+ <ul>
+  <li><strong><code>&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>master</code>, <code>feature1</code>, ...</li>
+  <li><strong><code>refs/heads/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...</li>
+  <li><strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one.<br> Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>origin/master</code></li>
+  <li><strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>remotes/origin/master</code></li>
+  <li><strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/remotes/origin/master</code></li>
+  <li><strong><code>&lt;tagName&gt;</code></strong><br> This does not work since the tag will not be recognized as tag.<br> Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br> E.g. <code>git-2.3.0</code></li>
+  <li><strong><code>refs/tags/&lt;tagName&gt;</code></strong><br> Tracks/checks out the specified tag.<br> E.g. <code>refs/tags/git-2.3.0</code></li>
+  <li><strong><code>&lt;commitId&gt;</code></strong><br> Checks out the specified commit.<br> E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...</li>
+  <li><strong><code>${ENV_VARIABLE}</code></strong><br> It is also possible to use environment variables. In this case the variables are evaluated and the result is used as described above.<br> E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...</li>
+  <li><strong><code>&lt;Wildcards&gt;</code></strong><br> The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>. In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.</li>
+  <li><strong><code>:&lt;regular expression&gt;</code></strong><br> The syntax is of the form: <code>:regexp</code>. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.<br> Examples:<br>
+   <ul>
+    <li><code>:^(?!(origin/prefix)).*</code>
+     <ul>
+      <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+      <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+     </ul></li>
+    <li><code>:origin/release-\d{8}</code>
+     <ul>
+      <li>matches: <code>origin/release-20150101</code></li>
+      <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+     </ul></li>
+    <li><code>:^(?!origin/master$|origin/develop$).*</code>
+     <ul>
+      <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+      <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+     </ul></li>
+   </ul></li>
+ </ul>
+ <p></p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>When running a job, Jenkins requires credentials to authenticate with Bitbucket Server. For example, to checkout the source code for builds. To do this, it needs credentials with access to the projects and repositories you want it to build from.</p>
+ <p>You can provide Jenkins with credentials here by:</p>
+ <ul>
+  <li>selecting credentials from the list</li>
+  <li>adding credentials as a <strong>Username with password</strong> (for the password, you can enter a Bitbucket Server password or a Bitbucket Server <a href="https://confluence.atlassian.com/x/a97-Nw" rel="nofollow">personal access token</a>)</li>
+ </ul>
+ <p>In addition, you can provide Jenkins with SSH credentials below. If you do, Jenkins will use them for clone operations instead of the credentials you select here.</p>
+</div></div>
+
+</li>
+<li><code>sshCredentialsId : String</code>
+<div><div>
+ <p>If specified, Jenkins will use these credentials to check out the source code for builds. If no SSH credentials are specified, Jenkins will use the basic credentials instead.</p>
+ <p>To provide Jenkins with SSH credentials, you can:</p>
+ <ul>
+  <li>choose credentials from the list</li>
+  <li>add credentials as a <strong>SSH Username with private key</strong> (the username must be "git")</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>extensions</code>
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AuthorInChangelog'</code><div>
+<div><div>
+ The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets. If this option is selected, the Git commit's "Author" value would be used instead.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'BuildChooserSetting'</code><div>
+<div><div>
+ When you are interested in using a job to build multiple heads (most typically multiple branches), you can choose how Jenkins choose what branches to build in what order. 
+ <p>This extension point in Jenkins is used by many other plugins to control the job to build specific commits. When you activate those plugins, you may see them installing a custom strategy here.</p>
+</div></div>
+<ul><li><code>buildChooser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AlternativeBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'AncestryBuildChooser'</code><div>
+<ul><li><code>maximumAgeInDays : int</code>
+</li>
+<li><code>ancestorCommitSha1 : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DefaultBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'DeflakeGitBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GerritTriggerBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'InverseBuildChooser'</code><div>
+<ul></ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'BuildSingleRevisionOnly'</code><div>
+<div><div>
+ Disable scheduling for multiple candidate revisions.<br> If we have 3 branches:<br> ----A--.---.--- B<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br> jenkins would try to build (B) and (C).<br> This behaviour disables this and only builds one of them.<br> It is helpful to reduce the load of the Jenkins infrastructure when the SCM system like Bitbucket or GitHub should decide what commits to build.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ChangelogToBranch'</code><div>
+<div><div>
+ This method calculates the changelog against the specified branch.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>compareRemote : String</code>
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below.
+</div></div>
+
+</li>
+<li><code>compareTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to compare against.
+</div></div>
+
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CheckoutOption'</code><div>
+<ul><li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for checkout.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanBeforeCheckout'</code><div>
+<div><div>
+ Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanCheckout'</code><div>
+<div><div>
+ Clean up the workspace after every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneOption'</code><div>
+<ul><li><code>shallow : boolean</code>
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code>
+<div><div>
+ Deselect this to perform a clone without tags, saving time and disk space when you just want to access what is specified by the refspec.
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for clone and fetch operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>honorRefspec : boolean</code> (optional)
+<div><div>
+ Perform initial clone using the refspec defined for the repository. This can save time, data transfer and disk space when you only need to access the references specified by the refspec.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CodeCommitURLHelper'</code><div>
+<ul><li><code>credentialId : String</code>
+<div><div>
+ <p>OPTIONAL: Select the credentials to use.<br> If not specified, defaults to the <a href="http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain" rel="nofollow"> DefaultAWSCredentialsProviderChain </a> behaviour - <b>*FROM THE JENKINS INSTANCE*</b></p>
+ <p>In the latter case, usage of IAM Role Profiles seems not to work, thus relying on environment variables / system properties or the ~/.aws/credentials file, thus not recommended.</p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DisableRemotePoll'</code><div>
+<div><div>
+ Git plugin uses git ls-remote polling mechanism by default when configured with a single branch (no wildcards!). This compare the latest built commit SHA with the remote branch without cloning a local copy of the repo.<br><br> If you don't want to / can't use this.<br><br> If this option is selected, polling will require a workspace and might trigger unwanted builds (see <a href="https://issues.jenkins.io/browse/JENKINS-10131" rel="nofollow">JENKINS-10131</a>).
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromChangeSet'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromPoll'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GitLFSPull'</code><div>
+<div><div>
+ Enable <a href="https://git-lfs.github.com/" rel="nofollow">git large file support</a> for the workspace by pulling large files after the checkout completes. Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'GitSCMChecksExtension'</code><div>
+<ul><li><code>verboseConsoleLog : boolean</code> (optional)
+<div><div>
+ If this option is checked, verbose log will be output to build console; the verbose log is useful for debugging the publisher creation.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCMStatusChecksExtension'</code><div>
+<ul><li><code>name : String</code> (optional)
+</li>
+<li><code>skip : boolean</code> (optional)
+</li>
+<li><code>skipProgressUpdates : boolean</code> (optional)
+</li>
+<li><code>suppressLogs : boolean</code> (optional)
+</li>
+<li><code>unstableBuildNeutral : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'GitTagMessageExtension'</code><div>
+<div><div>
+ If the revision checked out has a git tag associated with it, the tag name will be exported during the build as <strong>GIT_TAG_NAME</strong>. <br> If a message was specified when creating the tag, then that message will be exported during the build as the <strong>GIT_TAG_MESSAGE</strong> environment variable. <br> If no tag message was specified, the commit message will be used. <br> If you ticked the <strong>Use most recent tag</strong> option, and the revision checked out has no git tag associated with it, the parent commits will be searched for a git tag, and the rules stated above will apply to the first parent commit with a git tag. 
+ <p></p> If the revision has more than one tag associated with it, only the most recent tag will be taken into account, <strong>unless</strong> the refspec contains "refs/tags/" — i.e. builds are only triggered when certain tag names or patterns are matched — in which case the exact tag name that triggered the build will be used, even if it's not the most recent tag for this commit. <br> For this reason, if you're not using a tag-specific refspec but you <em>are</em> using the "Create a tag for every build" behaviour, you should make sure that the build-tagging behaviour is configured to run <em>after</em> this "export git tag message" behaviour. 
+ <p></p> Tag and commit messages which span multiple lines are no problem, though only the first 10000 lines of a tag's message will be exported.
+</div></div>
+<ul><li><code>useMostRecentTag : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IgnoreNotifyCommit'</code><div>
+<div><div>
+ If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository matches or not.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'LocalBranch'</code><div>
+<div><div>
+ If given, checkout the revision to build as HEAD on this branch. 
+ <p>If selected, and its value is an empty string or "**", then the branch name is computed from the remote branch without the origin. In that case, a remote branch origin/master will be checked out to a local branch named master, and a remote branch origin/develop/new-feature will be checked out to a local branch named develop/newfeature.</p>
+ <p>Please note that this has not been tested with submodules.</p>
+</div></div>
+<ul><li><code>localBranch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MessageExclusion'</code><div>
+<ul><li><code>excludedMessage : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct message. 
+ <p></p>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()" rel="nofollow">matching</a>
+ <p></p>
+ <pre>.*\[maven-release-plugin\].*</pre> The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have been committed to the SCM a build will not occur. 
+ <p></p> You can create more complex patterns using embedded flag expressions. 
+ <pre>(?s).*FOO.*</pre> This example will search FOO message in all comment lines.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PathRestriction'</code><div>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
+</div></div>
+<ul><li><code>includedRegions : String</code>
+<div><div>
+ Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. An empty list implies that everything is included. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that a build will only occur, if html/jpeg/gif files have been committed to the SCM. Exclusions take precedence over inclusions, if there is an overlap between included and excluded regions.
+</div></div>
+
+</li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PerBuildTag'</code><div>
+<div><div>
+ Create a tag in the workspace for every build to unambiguously mark the commit that was built. You can combine this with Git publisher to push the tags to the remote repository.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'PreBuildMerge'</code><div>
+<div><div>
+ These options allow you to perform a merge to a particular branch before building. For example, you could specify an integration branch to be built, and to merge to master. In this scenario, on every change of integration, Jenkins will perform a merge with the master branch, and try to perform a build if the merge is successful. It then may push the merge back to the remote repository if the Git Push post-build action is selected.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>mergeTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to merge to, such as <code>master</code>.
+</div></div>
+
+</li>
+<li><code>fastForwardMode</code> (optional)
+<div><div>
+ Merge fast-forward mode selection.<br> The default, --ff, gracefully falls back to a merge commit when required.<br> For more information, see the <a href="http://git-scm.com/docs/git-merge" rel="nofollow">Git Merge Documentation</a>
+</div></div>
+
+<ul><li><b>Values:</b> <code>FF</code>, <code>FF_ONLY</code>, <code>NO_FF</code></li></ul></li>
+<li><code>mergeRemote : String</code> (optional)
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below. If left blank, it'll default to the name of the first repository configured above.
+</div></div>
+
+</li>
+<li><code>mergeStrategy</code> (optional)
+<div><div>
+ Merge strategy selection. <strong>This feature is not fully implemented in JGIT.</strong>
+</div></div>
+
+<ul><li><b>Values:</b> <code>DEFAULT</code>, <code>RESOLVE</code>, <code>RECURSIVE</code>, <code>OCTOPUS</code>, <code>OURS</code>, <code>SUBTREE</code>, <code>RECURSIVE_THEIRS</code></li></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>pretestedIntegration</code><div>
+<ul><li><code>gitIntegrationStrategy</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>accumulated</code><div>
+<div><h2>Accumulated Commit Strategy</h2>
+<div>
+ This strategy merges your commits with the --no-ff switch
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>ffonly</code><div>
+<div><h2>Fast Forward only (--ff-only) Strategy</h2>
+<div>
+ This strategy fast-forward only using the --ff-only switch - or fails
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>squash</code><div>
+<div><h2>Squashed Commit Strategy</h2>
+<div>
+ This strategy squashes all your commit on a given branch with the --squash option
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>integrationBranch : String</code>
+<div><h3>What to specify</h3>
+<p>The branch name must match your integration branch name. <b>No trailing slash.</b></p>
+<h3>Merge is performed the following way</h3>
+<h5>Squash commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge --squash &lt;Branch matched by git&gt;
+            git commit -C &lt;Branch matched by git&gt;</pre>
+<h5>Accumulated commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge -m &lt;commitMsg&gt; &lt;Branch matched by git&gt; --no-ff</pre>
+<h3>When changes are pushed to the integration branch?</h3>
+<p>Changes are only ever pushed when the build results is SUCCESS</p>
+<pre>            git push &lt;Repository name&gt; &lt;Branch name&gt;</pre></div>
+
+</li>
+<li><code>repoName : String</code>
+<div><div>
+ <h3>What to specify</h3>
+ <p>The repository name. In git the repository is always the name of the remote. So if you have specified a repository name in your Git configuration. You need to specify the exact same name here, otherwise no integration will be performed. We do the merge based on this.</p>
+ <p><b>No trailing slash on repository name.</b></p>
+ <p><span>Remember to specify this when working with NAMED repositories in Git</span></p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PruneStaleBranch'</code><div>
+<div><div>
+ Run "git remote prune" for each remote, to prune obsolete local branches.
+</div></div>
+<ul></ul></div></li>
+<li><code>pruneTags</code><div>
+<ul><li><code>pruneTags : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RelativeTargetDirectory'</code><div>
+<ul><li><code>relativeTargetDir : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where the Git repository will be checked out. If left empty, the workspace root itself will be used. 
+ <p>This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted). Jenkins Pipeline already provides standard techniques for checkout to a subdirectory. Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" rel="nofollow">ws</a> and <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" rel="nofollow">dir</a> in Jenkins Pipeline rather than this extension.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmName'</code><div>
+<div><div>
+ <p>Unique name for this SCM. Needed when using Git within the Multi SCM plugin.</p>
+</div></div>
+<ul><li><code>name : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SparseCheckoutPaths'</code><div>
+<div><div>
+ <p>Specify the paths that you'd like to sparse checkout. This may be used for saving space (Think about a reference repository). Be sure to use a recent version of Git, at least above 1.7.10</p>
+</div></div>
+<ul><li><code>sparseCheckoutPaths</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>path : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'SubmoduleOption'</code><div>
+<ul><li><code>disableSubmodules : boolean</code>
+<div><div>
+ By disabling support for submodules you can still keep using basic git plugin functionality and just have Jenkins to ignore submodules completely as if they didn't exist.
+</div></div>
+
+</li>
+<li><code>recursiveSubmodules : boolean</code>
+<div><div>
+ Retrieve all submodules recursively (uses '--recursive' option which requires git&gt;=1.6.5)
+</div></div>
+
+</li>
+<li><code>trackingSubmodules : boolean</code>
+<div><div>
+ Retrieve the tip of the configured branch in .gitmodules (Uses '--remote' option which requires git&gt;=1.8.2)
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.<br> To prepare a reference folder with multiple subprojects, create a bare git repository and add all the remote urls then perform a fetch:<br>
+ <pre>  git init --bare
+  git remote add SubProject1 https://gitrepo.com/subproject1
+  git remote add SubProject2 https://gitrepo.com/subproject2
+  git fetch --all
+  </pre>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for submodules operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>parentCredentials : boolean</code>
+<div><div>
+ Use credentials from the default remote of the parent project.
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>shallow : boolean</code> (optional)
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>threads : int</code> (optional)
+<div><div>
+ Specify the number of threads that will be used to update submodules.<br> If unspecified, the command line git default thread count is used.<br>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserExclusion'</code><div>
+<ul><li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well. 
+ <p></p>Each exclusion uses exact string comparison and must be separated by a new line. User names are only excluded if they exactly match one of the names in this list. 
+ <p></p>
+ <pre>auto_build_user</pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserIdentity'</code><div>
+<ul><li><code>name : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+<li><code>email : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WipeWorkspace'</code><div>
+<div><div>
+ Delete the contents of the workspace before building, ensuring a fully fresh workspace.
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>gitTool : String</code>
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ <p>Enter the name of the Bitbucket Server project containing the repository you want Jenkins to build from. To find a project, start typing. If it doesn't appear in the search results, the credentials that you've chosen may not have read access to it and you'll need to provide different credentials.</p>
+ <p>To get Jenkins to build from a personal repository, enter a tilde (<code>~</code>) followed by repository owner's username. For example, <code>~jsmith.</code></p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+<div><div>
+ <p>Enter the Bitbucket Server repository you want Jenkins to build from. To find a repository, start typing. If it doesn't appear in the search results, the credentials that you've chosen may not have read access to it and you'll need to provide different credentials.</p>
+ <p>To get Jenkins to build from a personal repository, enter its slug. This is the URL-friendly version of the repository name. For example, a repository called my example repo will have the slug <em>my-example-repo</em>, and you can see this in its URL, https://bitbucketserver.mycompany.com/myproject/my-example-repo.</p>
+</div></div>
+
+</li>
+<li><code>serverId : String</code>
+<div><div>
+ <p>Choose the Bitbucket Server instance containing the repository you want Jenkins to build from. If you can't find your instance, check this plugin's configuration and try again.</p>
+</div></div>
+
+</li>
+<li><code>mirrorName : String</code>
+<div><div>
+ <p>Choose the location that Jenkins should clone from when running this build. This can be the primary server or a mirror if one is available. To see available mirrors, first choose a Bitbucket Server project and repository.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BlameSubversionSCM'</code><div>
+<div><div>
+ <p>if it is false and the build is not triggered by upstream job,</p>
+ <p></p>
+ <p>the plugin will not collect any svn info from upstream job.</p>
+ <p>else the plugin will collect svn info from latest upstream job</p>
+</div></div>
+<ul><li><code>alwaysCollectSVNInfo : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CCUCMScm'</code><div>
+<ul><li><code>loadModule : String</code>
+</li>
+<li><code>newest : boolean</code>
+</li>
+<li><code>mode</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'PollChildMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+<div><div>
+ <p>Check this if you want create a baseline after a completed deliver.</p>
+ <p>This is only applicable for child and sibling poll mode.</p>
+</div></div>
+
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollRebaseMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+<div><div>
+ The component used to figure out the correct baseline to recommend due to the following bug: <br> <a href="http://www-01.ibm.com/support/docview.wss?uid=swg21269043" rel="nofollow">http://www-01.ibm.com/support/docview.wss?uid=swg21269043</a>
+</div></div>
+
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+</li>
+<li><code>excludeList : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSelfMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSiblingMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+<div><div>
+ <p>Check this if you want create a baseline after a completed deliver.</p>
+ <p>This is only applicable for child and sibling poll mode.</p>
+</div></div>
+
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+<li><code>useHyperLinkForPolling : boolean</code> (optional)
+<div><div>
+ Instead of using the integration streams default deliver target. Use the value specified in the hyperlink. The hyperlink type to be used can be configured in the global configuration.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSubscribeMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>componentsToMonitor</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>componentSelection : String</code>
+</li>
+</ul></li>
+<li><code>jobsToMonitor</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>jobname : String</code>
+</li>
+<li><code>ignores : String</code>
+<div><div>
+ A comma seperated list of components which should not be included when checking if the requirements are met. That is to say that not all components are interesting in every job specified.
+</div></div>
+
+</li>
+<li><code>jobName : String</code> (optional)
+<div><div>
+ Specifies the name of the job in which all selected baselines must be present.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>cascadePromotion : boolean</code> (optional)
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>newest : boolean</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>stream : String</code>
+<div><div>
+ Specify the stream you want to poll for with ClearCase UCM SCM. Syntax: [stream]@[PVOB]
+</div></div>
+
+</li>
+<li><code>treatUnstable : String</code>
+</li>
+<li><code>nameTemplate : String</code>
+</li>
+<li><code>forceDeliver : boolean</code>
+</li>
+<li><code>recommend : boolean</code>
+</li>
+<li><code>makeTag : boolean</code>
+</li>
+<li><code>setDescription : boolean</code>
+</li>
+<li><code>buildProject : String</code>
+</li>
+<li><code>removeViewPrivateFiles : boolean</code>
+</li>
+<li><code>trimmedChangeSet : boolean</code>
+</li>
+<li><code>discard : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CVSSCM'</code><div>
+<ul><li><code>repositories</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>cvsRoot : String</code>
+<div><div>
+ The CVS connection string Jenkins uses to connect to the server. The format is the same as $CVSROOT environment variable (:protocol:user@host:path)
+</div></div>
+
+</li>
+<li><code>passwordRequired : boolean</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryItems</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>location</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'BranchRepositoryLocation'</code><div>
+<ul><li><code>branchName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'HeadRepositoryLocation'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TagRepositoryLocation'</code><div>
+<ul><li><code>tagName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>modules</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remoteName : String</code>
+<div><div>
+ The name of the module in the repository at CVSROOT
+</div></div>
+
+</li>
+<li><code>localName : String</code>
+<div><div>
+ The name to be applied to this module in the local workspace. If this is left blank then the remote module name will be used. This is similar to the 'checkout-as' function available on many CVS clients.
+</div></div>
+
+</li>
+<li><code>projectsetFileName : String</code>
+<div><div>
+ The name of the file in this module to parse for projectset entries.
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+<li><code>excludedRegions</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p>Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 src/main/web/.*\.html
+	 src/main/web/.*\.jpeg
+	 src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p>More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pattern : String</code>
+</li>
+</ul></li>
+<li><code>compressionLevel : int</code>
+</li>
+<li><code>repositoryBrowser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+</ul></li>
+<li><code>canUseUpdate : boolean</code>
+<div><div>
+ If checked, Jenkins will use 'cvs update' whenever possible for builds. This makes a build faster. But this also causes the artifacts from the previous build to remain in the file system when a new build starts, making it not a true clean build.
+</div></div>
+
+</li>
+<li><code>legacy : boolean</code>
+<div><div>
+ Hudson 1.20 and earlier used to create redundant directories inside the workspace. For example, if the CVS module name is "foo/bar", it first created "foo/bar" and then put everything below. With this option checked off, there will be no more such unnecessary intermediate directories. 
+ <p>If you have multiple modules to check out, this option is forced (otherwise they'll overlap.)</p>
+ <p>This affects other path specifiers, such as artifact archivers --- you now specify "build/foo.jar" instead of "foo/build/foo.jar".</p>
+</div></div>
+
+</li>
+<li><code>skipChangeLog : boolean</code>
+<div><div>
+ Prevent the changelog being generated after checkout has completed. This will stop any changes being shown on the changes screen but reduces load on your CVS server.
+</div></div>
+
+</li>
+<li><code>pruneEmptyDirectories : boolean</code>
+<div><div>
+ Remove empty directories after checkout using the CVS '-P' option.
+</div></div>
+
+</li>
+<li><code>disableCvsQuiet : boolean</code>
+<div><div>
+ Instructs CVS to show all logging output. CVS normally runs in quiet mode but this option disables that.
+</div></div>
+
+</li>
+<li><code>cleanOnFailedUpdate : boolean</code>
+<div><div>
+ If the job is configured to use CVS update and the update step fails for any reason then the workspace will be wiped-out and a clean checkout done instead.
+</div></div>
+
+</li>
+<li><code>forceCleanCopy : boolean</code>
+<div><div>
+ If checked, Jenkins will add the 'C' option to the CVS update command to force it to over-write any files with local modifications, rather than attempt a merge or leave them as they are.
+</div></div>
+
+</li>
+<li><code>checkoutCurrentTimestamp : boolean</code>
+<div><div>
+ Advanced option. Should probably be left unchecked. 
+ <p>The build quiet period is designed to assist with CVS checkouts by waiting for a specific period of time without commits. Normally you want the checkout to reflect the time when the quiet period was exited successfully. Select this option if you need to re-enable the legacy behaviour of Jenkins, i.e. using the time that the build started checking out as the timestamp for the checkout operation. Note: enabling this option can result in the quiet period being defeated especially in those cases where the build is not able to start immediately after exiting the quiet period.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ClearCaseSCM'</code><div>
+<ul><li><code>branch : String</code>
+</li>
+<li><code>label : String</code>
+</li>
+<li><code>extractConfigSpec : boolean</code>
+</li>
+<li><code>configSpecFileName : String</code>
+</li>
+<li><code>refreshConfigSpec : boolean</code>
+</li>
+<li><code>refreshConfigSpecCommand : String</code>
+</li>
+<li><code>configSpec : String</code>
+</li>
+<li><code>viewTag : String</code>
+</li>
+<li><code>useupdate : boolean</code>
+</li>
+<li><code>extractLoadRules : boolean</code>
+</li>
+<li><code>loadRules : String</code>
+</li>
+<li><code>useOtherLoadRulesForPolling : boolean</code>
+</li>
+<li><code>loadRulesForPolling : String</code>
+</li>
+<li><code>usedynamicview : boolean</code>
+</li>
+<li><code>viewdrive : String</code>
+</li>
+<li><code>mkviewoptionalparam : String</code>
+</li>
+<li><code>filterOutDestroySubBranchEvent : boolean</code>
+</li>
+<li><code>doNotUpdateConfigSpec : boolean</code>
+</li>
+<li><code>rmviewonrename : boolean</code>
+</li>
+<li><code>excludedRegions : String</code>
+</li>
+<li><code>multiSitePollBuffer : String</code>
+</li>
+<li><code>useTimeRule : boolean</code>
+</li>
+<li><code>createDynView : boolean</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>changeset</code>
+<ul><li><b>Values:</b> <code>ALL</code>, <code>BRANCH</code>, <code>NONE</code>, <code>UPDT</code></li></ul></li>
+<li><code>viewStorage</code>
+<div><p>Three strategies are currently available to manage view storage location.</p>
+<ul>
+ <li><b>Default</b>. This entry doesn't generate any additional argument to the <i>cleartool mkview</i> command. The behaviour will change depending on how your clearcase server is configured.</li>
+ <li><b>Use server storage location</b>. This entry generates a <i>-stgloc</i> argument to the <i>cleartool mkview</i> command.</li>
+ <li><b>Use explicit path</b>. This entry generates a <i>-vws</i> argument to the <i>cleartool mkview</i> command.</li>
+</ul>
+<p></p></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DefaultViewStorage'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ServerViewStorage'</code><div>
+<ul><li><code>assignedLabelString : String</code>
+<div><p>Label expression used to populate view storage location dropdown.</p></div>
+
+</li>
+<li><code>server : String</code>
+<div><p>The view storage location that will be passed to the <i>-stgloc</i> option.<br> The list of available servers is retrieved using <i>cleartool lsstgloc -view</i><br> Note that auto is always available.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SpecificViewStorage'</code><div>
+<ul><li><code>winStorageDir : String</code>
+</li>
+<li><code>unixStorageDir : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'ClearCaseUcmBaselineSCM'</code><div>
+<div><div>
+ When used (and fully set up), this option will display a field at build-time so that the user is able to select a ClearCase UCM baseline from which to download the content for this project.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ClearCaseUcmSCM'</code><div>
+<ul><li><code>stream : String</code>
+</li>
+<li><code>loadrules : String</code>
+</li>
+<li><code>viewTag : String</code>
+</li>
+<li><code>usedynamicview : boolean</code>
+</li>
+<li><code>viewdrive : String</code>
+</li>
+<li><code>mkviewoptionalparam : String</code>
+</li>
+<li><code>filterOutDestroySubBranchEvent : boolean</code>
+</li>
+<li><code>useUpdate : boolean</code>
+</li>
+<li><code>rmviewonrename : boolean</code>
+</li>
+<li><code>excludedRegions : String</code>
+</li>
+<li><code>multiSitePollBuffer : String</code>
+</li>
+<li><code>overrideBranchName : String</code>
+</li>
+<li><code>createDynView : boolean</code>
+</li>
+<li><code>freezeCode : boolean</code>
+</li>
+<li><code>recreateView : boolean</code>
+</li>
+<li><code>allocateViewName : boolean</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>useManualLoadRules : boolean</code>
+</li>
+<li><code>changeset</code>
+<ul><li><b>Values:</b> <code>ALL</code>, <code>BRANCH</code>, <code>NONE</code>, <code>UPDT</code></li></ul></li>
+<li><code>viewStorage</code>
+<div><p>Three strategies are currently available to manage view storage location.</p>
+<ul>
+ <li><b>Default</b>. This entry doesn't generate any additional argument to the <i>cleartool mkview</i> command. The behaviour will change depending on how your clearcase server is configured.</li>
+ <li><b>Use server storage location</b>. This entry generates a <i>-stgloc</i> argument to the <i>cleartool mkview</i> command.</li>
+ <li><b>Use explicit path</b>. This entry generates a <i>-vws</i> argument to the <i>cleartool mkview</i> command.</li>
+</ul>
+<p></p></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DefaultViewStorage'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ServerViewStorage'</code><div>
+<ul><li><code>assignedLabelString : String</code>
+<div><p>Label expression used to populate view storage location dropdown.</p></div>
+
+</li>
+<li><code>server : String</code>
+<div><p>The view storage location that will be passed to the <i>-stgloc</i> option.<br> The list of available servers is retrieved using <i>cleartool lsstgloc -view</i><br> Note that auto is always available.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SpecificViewStorage'</code><div>
+<ul><li><code>winStorageDir : String</code>
+</li>
+<li><code>unixStorageDir : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>buildFoundationBaseline : boolean</code>
+<div><p>If checked, instead of creating a view on the current stream, the job will look up the current foundation baselines for the given stream and work in readonly on these baselines. If polling is enabled, the build will be triggered every time a new foundation baseline is detected on the given stream.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneWorkspaceSCM'</code><div>
+<ul><li><code>parentJobName : String</code>
+</li>
+<li><code>criteria : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CmvcSCM'</code><div>
+<ul><li><code>family : String</code>
+</li>
+<li><code>become : String</code>
+</li>
+<li><code>releases : String</code>
+</li>
+<li><code>checkoutScript : String</code>
+</li>
+<li><code>trackViewReportWhereClause : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ConfigurationRotator'</code><div>
+<ul><li><code>acrs</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'ClearCaseUCM'</code><div>
+<ul><li><code>pvobName : String</code>
+</li>
+<li><code>contribute : boolean</code>
+<div><div>
+ <p>Contribute data to a global database. Defined in the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Compatibility+Action+Storage+Plugin" rel="nofollow">Compatibility Action Storage Plugin</a>.</p>
+</div></div>
+
+</li>
+<li><code>targets</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>baselineName : String</code>
+</li>
+<li><code>level</code>
+<ul><li><b>Values:</b> <code>INITIAL</code>, <code>BUILT</code>, <code>TESTED</code>, <code>RELEASED</code>, <code>REJECTED</code></li></ul></li>
+<li><code>fixed : boolean</code>
+</li>
+</ul></li>
+<li><code>useNewest : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'Git'</code><div>
+<ul><li><code>targets</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+</li>
+<li><code>repository : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+<li><code>commitId : String</code>
+</li>
+<li><code>fixed : boolean</code>
+</li>
+</ul></li>
+<li><code>useNewest : boolean</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CvsProjectset'</code><div>
+<ul><li><code>repositories</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>cvsRoot : String</code>
+<div><div>
+ The CVS connection string Jenkins uses to connect to the server. The format is the same as $CVSROOT environment variable (:protocol:user@host:path)
+</div></div>
+
+</li>
+<li><code>passwordRequired : boolean</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryItems</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>location</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'BranchRepositoryLocation'</code><div>
+<ul><li><code>branchName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'HeadRepositoryLocation'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TagRepositoryLocation'</code><div>
+<ul><li><code>tagName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>modules</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remoteName : String</code>
+<div><div>
+ The name of the module in the repository at CVSROOT
+</div></div>
+
+</li>
+<li><code>localName : String</code>
+<div><div>
+ The name to be applied to this module in the local workspace. If this is left blank then the remote module name will be used. This is similar to the 'checkout-as' function available on many CVS clients.
+</div></div>
+
+</li>
+<li><code>projectsetFileName : String</code>
+<div><div>
+ The name of the file in this module to parse for projectset entries.
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+<li><code>excludedRegions</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p>Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 src/main/web/.*\.html
+	 src/main/web/.*\.jpeg
+	 src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p>More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pattern : String</code>
+</li>
+</ul></li>
+<li><code>compressionLevel : int</code>
+</li>
+<li><code>repositoryBrowser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+</ul></li>
+<li><code>canUseUpdate : boolean</code>
+<div><div>
+ If checked, Jenkins will use 'cvs update' whenever possible for builds. This makes a build faster. But this also causes the artifacts from the previous build to remain in the file system when a new build starts, making it not a true clean build.
+</div></div>
+
+</li>
+<li><code>username : String</code>
+<div><div>
+ This username will be used for the checkout of any modules parsed from the projectset file if no match was found against the parsed CVSROOT using the globally configured authentication.
+</div></div>
+
+</li>
+<li><code>password : String</code>
+<div><div>
+ This password will be used for the checkout of any modules parsed from the projectset file if no match was found against the parsed CVSROOT using the globally configured authentication.
+</div></div>
+
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>skipChangeLog : boolean</code>
+<div><div>
+ Prevent the changelog being generated after checkout has completed. This will stop any changes being shown on the changes screen but reduces load on your CVS server.
+</div></div>
+
+</li>
+<li><code>pruneEmptyDirectories : boolean</code>
+<div><div>
+ Remove empty directories after checkout using the CVS '-P' option.
+</div></div>
+
+</li>
+<li><code>disableCvsQuiet : boolean</code>
+<div><div>
+ Instructs CVS to show all logging output. CVS normally runs in quiet mode but this option disables that.
+</div></div>
+
+</li>
+<li><code>cleanOnFailedUpdate : boolean</code>
+<div><div>
+ If the job is configured to use CVS update and the update step fails for any reason then the workspace will be wiped-out and a clean checkout done instead.
+</div></div>
+
+</li>
+<li><code>forceCleanCopy : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DarcsScm'</code><div>
+<ul><li><code>source : String</code>
+</li>
+<li><code>localDir : String</code>
+</li>
+<li><code>clean : boolean</code>
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DarcsWeb'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'Darcsden'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'DimensionsSCM'</code><div>
+<ul><li><code>project : String</code>
+</li>
+<li><code>credentialsType : String</code>
+</li>
+<li><code>userName : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>pluginServer : String</code>
+</li>
+<li><code>userServer : String</code>
+</li>
+<li><code>keystoreServer : String</code>
+</li>
+<li><code>pluginDatabase : String</code>
+</li>
+<li><code>userDatabase : String</code>
+</li>
+<li><code>keystoreDatabase : String</code>
+</li>
+<li><code>keystorePath : String</code>
+</li>
+<li><code>certificateAlias : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>certificatePassword : String</code>
+</li>
+<li><code>keystorePassword : String</code>
+</li>
+<li><code>certificatePath : String</code>
+</li>
+<li><code>remoteCertificatePassword : String</code>
+</li>
+<li><code>secureAgentAuth : boolean</code>
+</li>
+<li><code>canJobDelete : boolean</code> (optional)
+</li>
+<li><code>canJobExpand : boolean</code> (optional)
+</li>
+<li><code>canJobForce : boolean</code> (optional)
+</li>
+<li><code>canJobNoMetadata : boolean</code> (optional)
+</li>
+<li><code>canJobNoTouch : boolean</code> (optional)
+</li>
+<li><code>canJobRevert : boolean</code> (optional)
+</li>
+<li><code>canJobUpdate : boolean</code> (optional)
+</li>
+<li><code>eol : String</code> (optional)
+</li>
+<li><code>folders</code> (optional)
+<ul><b>Array / List of Nested Object</b>
+<li><code>value : String</code>
+</li>
+</ul></li>
+<li><code>pathsToExclude</code> (optional)
+<ul><b>Array / List of Nested Object</b>
+<li><code>value : String</code>
+</li>
+</ul></li>
+<li><code>permissions : String</code> (optional)
+</li>
+<li><code>timeZone : String</code> (optional)
+</li>
+<li><code>webUrl : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'DrushMakefileSCM'</code><div>
+<ul><li><code>makefile : String</code>
+<div><div>
+ <p>Specify the content of the <a href="https://www.drupal.org/node/1432374" rel="nofollow">Makefile</a>. Support for YAML Makefiles depends on the version of Drush you have installed.</p>
+ <p>This example will generate a vanilla Drupal 7.38:</p>
+ <pre>    api=2
+    core=7.x
+    projects[drupal][version]=7.38
+    </pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>root : String</code>
+<div><div>
+ Specify a local directory for the Drupal root (relative to the <a rel="nofollow">workspace root</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'EndevorConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>filterPattern : String</code>
+</li>
+<li><code>fileExtension : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+</ul></div></li>
+<li><code>filesystem</code><div>
+<ul><li><code>path : String</code>
+<div><div>
+ <p>The file path for the source code.</p>
+ <p>e.g. \\Server1\project1\src or c:\myproject\src</p>
+ <p>Note for distributed build environment, please make sure the path is accessible on remote node(s)</p>
+</div></div>
+
+</li>
+<li><code>clearWorkspace : boolean</code>
+<div><div>
+ <p>If true, the system will delete all existing files/sub-folders in workspace before checking-out. Poll changes will not be affected by this setting.</p>
+</div></div>
+
+</li>
+<li><code>copyHidden : boolean</code>
+<div><div>
+ <p>If true, the system will copy hidden files and folders as well. Default is false.</p>
+</div></div>
+
+</li>
+<li><code>filterSettings</code>
+<ul><b>Nested Object</b>
+<li><code>includeFilter : boolean</code>
+</li>
+<li><code>selectors</code>
+<div><div>
+ <p>You can apply wildcard filter(s) when detecting changes and copying files. By default, the system will filter out hidden files, on Unix, that means files/folder starting with ".", on Windows, that means files/folders with "hidden" attribute. You may want to filter out, e.g. files with ".tmp" extension.</p>
+ <p>Note: filters are applied on both sides, source and destination (i.e. the workspace). E.g. if you filter out ".tmp" files, all ".tmp" files currently in workspace will not be removed.</p>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>wildcard : String</code>
+<div><div>
+ <p>ANT style wildcard.</p>
+ <p>To include just *.java, set filter type to "Include" and type add "*.java" (without quote) in the wildcard. To exclude *.exe" and all JUnit test cases, set filter type to "Exclude" and add two wildcard, one for "*.dll" and one for "*Test*"</p>
+ <p>To exclude a directory, set filter to "**/dir_to_exclude/**"</p>
+ <p>Note: (1) the wildcard is case insensitive, (2) all backslashes (\) will be replaced with slashes (/)</p>
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'FeatureBranchAwareMercurialSCM'</code><div>
+<ul><li><code>installation : String</code>
+</li>
+<li><code>source : String</code>
+<div><div>
+ Specify the repository to track. This can be URL or a local file path.
+</div></div>
+
+</li>
+<li><code>branch : String</code>
+<div><div>
+ Specify the branch name if you'd like to track a specific branch in a repository. Leave this field empty otherwise, to track the "default" branch.
+</div></div>
+
+</li>
+<li><code>modules : String</code>
+<div><div>
+ Reduce unnecessary builds by specifying a comma or space delimited list of "modules" within the repository. A module is a directory name within the repository that this project lives in. If this field is set, changes outside the specified modules will not trigger a build (even though the whole repository is checked out anyway due to the Mercurial limitation.)
+</div></div>
+
+</li>
+<li><code>subdir : String</code>
+<div><div>
+ If not empty, check out the Mercurial repository into this subdirectory of the job's workspace. For example: <code>my/sources</code> (use forward slashes). If changing this entry, you probably want to clean the workspace first.
+</div></div>
+
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEye'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository, such as: http://www.example.org/browse/hg/
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GoogleCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="http://code.google.com/p/PROJECTNAME/source/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'HgWeb'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://www.mercurial-scm.org/repo/hg/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Kallithea'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnHG'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://acme.kilnhg.com/Repo/Repositories/Group/PROJECTNAME" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCodeLegacy'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManager'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <code>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</code>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>clean : boolean</code>
+<div><div>
+ When this option is checked, each build will wipe any local modifications or untracked files in the repository checkout. This is often a convenient way to ensure that a build is not using any artifacts from earlier builds.
+</div></div>
+
+</li>
+<li><code>branchPattern : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'GeneXusServerSCM'</code><div>
+<div><div>
+ Checks out (or updates) a Knowledge Base from a GeneXus&nbsp;Server.
+</div></div>
+<ul><li><code>gxInstallationId : String</code>
+<div><div>
+ <p>GeneXus installation to use when creating (or updating) a local copy of a Knowledge&nbsp;Base from a GeneXus&nbsp;Server.</p>
+ <p>Select "(Custom)" if you want to specify a custom GeneXus path for this project (see Advanced Options).</p>
+ <p>The options that appear here are those you may configure in Jenkins "Global Tool Configuration" for GeneXus.</p>
+</div></div>
+
+</li>
+<li><code>gxCustomPath : String</code>
+<div><div>
+ <p>Custom path to a GeneXus installation to use when creating (or updating) a local copy of Knowledge&nbsp;Base from a GeneXus&nbsp;Server. This custom path is used when the "Custom" option is selected for the GeneXus&nbsp;Installation</p>
+</div></div>
+
+</li>
+<li><code>msbuildCustomPath : String</code>
+<div><div>
+ <p>Custom path to the MSBuild installation to use when creating (or updating) a local copy of Knowledge&nbsp;Base from a GeneXus&nbsp;Server.</p>
+</div></div>
+
+</li>
+<li><code>serverURL : String</code>
+<div><div>
+ URL of the GeneXus&nbsp;Server from which to obtain (or update) a local copy of a Knowledge&nbsp;Base (eg:&nbsp;"https://sandbox.genexusserver.com/v16").
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>Credentials to use when authenticating to the GeneXus&nbsp;Server.</p>
+ <p>Select the credentials you want to use or click "Add" to enter a new user/password pair.</p>
+</div></div>
+
+</li>
+<li><code>kbName : String</code>
+<div><div>
+ Name of the Knowledge&nbsp;Base in GeneXus&nbsp;Server from which to obtain (or update) a local copy.
+</div></div>
+
+</li>
+<li><code>kbVersion : String</code>
+<div><div>
+ <p>Name of the Version that will be selected when creating a local copy of the Knowledge Base.</p>
+ <p>If you leave it blank the 'Trunk' version will be selected by default.</p>
+</div></div>
+
+</li>
+<li><code>localKbPath : String</code>
+<div><div>
+ <p>Path to the local Knowledge Base to use as working copy.</p>
+ <p>If you leave it blank the default <code>${WORKSPACE}\KBname</code> will apply.</p>
+</div></div>
+
+</li>
+<li><code>localKbVersion : String</code>
+<div><div>
+ <p>Name of the Version in the local Knowledge Base that is linked to the Version in the server.</p>
+ <p>If you leave it blank the 'Trunk' version will be selected by default.</p>
+</div></div>
+
+</li>
+<li><code>kbDbServerInstance : String</code>
+<div><div>
+ SQL Server used by GeneXus for the local Knowledge Base.
+</div></div>
+
+</li>
+<li><code>kbDbCredentialsId : String</code>
+<div><div>
+ <p>Credentials to use when to connecting to SQL&nbsp;Server.</p>
+ <p>Select "none" for Windows Authentication.</p>
+</div></div>
+
+</li>
+<li><code>kbDbName : String</code>
+<div><div>
+ <p>Name of the SQL Server database used for the local Knowledge&nbsp;Base.</p>
+ <p>Leave it blank to use the default database name.</p>
+</div></div>
+
+</li>
+<li><code>kbDbInSameFolder : boolean</code>
+<div><div>
+ <p>Create the database files in the same folder as the Knowledge&nbsp;Base when checking out. Default is '<code>true</code>'.</p>
+ <p>If <code>kbDbInSameFolder</code> is true or not set, then the database files will be created in the same folder as the Knowledge&nbsp;Base. If <code>kbDbInSameFolder</code> is false, then the database files will be created in the default folder configured for the SQL Server at <code>kbDbServerInstance (optional)</code>.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCM'</code><div>
+<div><div>
+ <p>The <a href="https://plugins.jenkins.io/git/" rel="nofollow">git plugin</a> provides fundamental git operations for Jenkins projects. It can poll, fetch, checkout, and merge contents of git repositories.</p>
+ <p>The git plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step" rel="nofollow"><code>checkout</code></a> step. The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator" rel="nofollow"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.</p>
+</div></div>
+<ul><li><code>userRemoteConfigs</code>
+<div><div>
+ Specify the repository to track. This can be a URL or a local file path. Note that for super-projects (repositories with submodules), only a local file path or a complete URL is valid. The following are examples of valid git URLs. 
+ <ul>
+  <li>ssh://git@github.com/github/git.git</li>
+  <li>git@github.com:github/git.git (short notation for ssh protocol)</li>
+  <li>ssh://user@other.host.com/~/repos/R.git (to access the repos/R.git repository in the user's home directory)</li>
+  <li>https://github.com/github/git.git</li>
+ </ul> <br> If the repository is a super-project, the location from which to clone submodules is dependent on whether the repository is bare or non-bare (i.e. has a working directory). 
+ <ul>
+  <li>If the super-project is bare, the location of the submodules will be taken from <em>.gitmodules</em>.</li>
+  <li>If the super-project is <strong>not</strong> bare, it is assumed that the repository has each of its submodules cloned and checked out appropriately. Thus, the submodules will be taken directly from a path like <code>${SUPER_PROJECT_URL}/${SUBMODULE}</code>, rather than relying on information from <em>.gitmodules</em>.</li>
+ </ul> For a local URL/path to a super-project, <em>git rev-parse --is-bare-repository</em> is used to detect whether the super-project is bare or not. <br> For a remote URL to a super-project, the ending of the URL determines whether a bare or non-bare repository is assumed: 
+ <ul>
+  <li>If the remote URL ends with <em>/.git</em>, a <em>non</em>-bare repository is assumed.</li>
+  <li>If the remote URL does <strong>NOT</strong> end with <em>/.git</em>, a bare repository is assumed.</li>
+ </ul>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>url : String</code>
+<div><div>
+ Specify the URL or path of the git repository. This uses the same syntax as your <code>git clone</code> command.
+</div></div>
+
+</li>
+<li><code>name : String</code>
+<div><div>
+ ID of the repository, such as <code>origin</code>, to uniquely identify this repository among other remote repositories. This is the same "name" that you use in your <code>git remote</code> command. If left empty, Jenkins will generate unique names for you. 
+ <p>You normally want to specify this when you have multiple remote repositories.</p>
+</div></div>
+
+</li>
+<li><code>refspec : String</code>
+<div><div>
+ A refspec controls the remote refs to be retrieved and how they map to local refs. If left blank, it will default to the normal behaviour of <code>git fetch</code>, which retrieves all the branch heads as <code>remotes/REPOSITORYNAME/BRANCHNAME</code>. This default behaviour is OK for most cases. 
+ <p>In other words, the default refspec is "+refs/heads/*:refs/remotes/REPOSITORYNAME/*" where <code>REPOSITORYNAME</code> is the value you specify in the above "name of repository" textbox.</p>
+ <p>When do you want to modify this value? A good example is when you want to just retrieve one branch. For example, <code>+refs/heads/master:refs/remotes/origin/master</code> would only retrieve the master branch and nothing else.</p>
+ <p>The plugin uses a default refspec for its initial fetch, unless the "Advanced Clone Option" is set to honor refspec. This keeps compatibility with previous behavior, and allows the job definition to decide if the refspec should be honored on initial clone.</p>
+ <p>Multiple refspecs can be entered by separating them with a space character. <code>+refs/heads/master:refs/remotes/origin/master&nbsp;+refs/heads/develop:refs/remotes/origin/develop</code> retrieves the master branch and the develop branch and nothing else.</p>
+ <p>See <a href="https://git-scm.com/book/en/v2/Git-Internals-The-Refspec" rel="nofollow">the refspec definition in Git user manual</a> for more details.</p>
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ Credential used to <strong>check out</strong> sources.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>branches</code>
+<div><div>
+ List of branches to build. Jenkins jobs are most effective when each job builds only a single branch. When a single job builds multiple branches, the changelog comparisons between branches often show no changes or incorrect changes.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+<div><div>
+ <p>Specify the branches if you'd like to track a specific branch in a repository. If left blank, all branches will be examined for changes and built.</p>
+ <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch is unambiguous.</p>
+ <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented with a full path the plugin will only use the part of the string right of the last slash. Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+ <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>), you'll need to specify the origin repository in the branch names to make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+ <p>Possible options:</p>
+ <ul>
+  <li><strong><code>&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>master</code>, <code>feature1</code>, ...</li>
+  <li><strong><code>refs/heads/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...</li>
+  <li><strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one.<br> Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>origin/master</code></li>
+  <li><strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>remotes/origin/master</code></li>
+  <li><strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/remotes/origin/master</code></li>
+  <li><strong><code>&lt;tagName&gt;</code></strong><br> This does not work since the tag will not be recognized as tag.<br> Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br> E.g. <code>git-2.3.0</code></li>
+  <li><strong><code>refs/tags/&lt;tagName&gt;</code></strong><br> Tracks/checks out the specified tag.<br> E.g. <code>refs/tags/git-2.3.0</code></li>
+  <li><strong><code>&lt;commitId&gt;</code></strong><br> Checks out the specified commit.<br> E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...</li>
+  <li><strong><code>${ENV_VARIABLE}</code></strong><br> It is also possible to use environment variables. In this case the variables are evaluated and the result is used as described above.<br> E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...</li>
+  <li><strong><code>&lt;Wildcards&gt;</code></strong><br> The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>. In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.</li>
+  <li><strong><code>:&lt;regular expression&gt;</code></strong><br> The syntax is of the form: <code>:regexp</code>. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.<br> Examples:<br>
+   <ul>
+    <li><code>:^(?!(origin/prefix)).*</code>
+     <ul>
+      <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+      <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+     </ul></li>
+    <li><code>:origin/release-\d{8}</code>
+     <ul>
+      <li>matches: <code>origin/release-20150101</code></li>
+      <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+     </ul></li>
+    <li><code>:^(?!origin/master$|origin/develop$).*</code>
+     <ul>
+      <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+      <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+     </ul></li>
+   </ul></li>
+ </ul>
+ <p></p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>browser</code>
+<div><div>
+ Defines the repository browser that displays changes detected by the git plugin.
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AssemblaWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://www.assembla.com/code/PROJECT/git/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BacklogGitRepositoryBrowser'</code><div>
+<ul><li><code>repoName : String</code>
+</li>
+<li><code>repoUrl : String</code>
+</li>
+</ul></div></li>
+<li><code>bitbucketServer</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the Bitbucket Server root URL for this repository (such as <em>https://bitbucket:7990/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BitbucketWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://bitbucket.org/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://cgit.example.com:port/group/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'FisheyeGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the URL of this repository in FishEye (such as <em>http://fisheye6.cenqua.com/browse/ant/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBlitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository.
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in GitBlit.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBucketBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLab'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlabserver:port/group/REPO/</em>).
+</div></div>
+
+</li>
+<li><code>version : String</code> (optional)
+<div><div>
+ Specify the major and minor version of GitLab you use (such as 9.1). If you don't specify a version, a modern version of GitLab (&gt;= 8.0) is assumed.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLabBrowser'</code><div>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page so that links to changes can be automatically generated by Jenkins. The URL needs to include the owner and project. If the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>.
+</div></div>
+<ul><li><code>projectUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page. The URL needs to include the owner and project so, for example, if the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitList'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlistserver:port/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://github.com/jenkinsci/jenkins.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GiteaBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Gitea page. The URL needs to include the owner and repository so, for example, if the Gitea server is <code>https://gitea.example.com</code> then the URL for bob's skunkworks project repository might be <code>https://gitea.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GithubWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's GitHub page (such as <em>https://github.com/jquery/jquery</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Gitiles'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gwt.googlesource.com/gwt/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitoriousWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gitorious.org/gitorious/mainline</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GogsGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gogs.example.com:port/username/some-repo-url.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://khanacademy.kilnhg.com/Code/Website/Group/webapp</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Phabricator'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the phabricator instance root URL (such as <em>http://phabricator.example.com</em>).
+</div></div>
+
+</li>
+<li><code>repo : String</code>
+<div><div>
+ Specify the repository name in phabricator (such as the <em>foo</em> part of <em>phabricator.example.com/diffusion/foo/browse</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RedmineWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://SERVER/PATH/projects/PROJECT/repository</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's RhodeCode page (such as <em>http://rhodecode.mydomain.com:5000/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManagerGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://scm-manager.org/scm/repo/namespace/name</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Stash'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Stash page (such as <em>http://stash.mydomain.com:7990/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TFS2013GitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Either the name of the remote whose URL should be used, or the URL of this module in TFS (such as <em>http://fisheye6.cenqua.com/tfs/PROJECT/_git/REPO/</em>). If empty (default), the URL of the "origin" repository is used. 
+ <p>If TFS is also used as the repository server, this can usually be left blank.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TracGitRepositoryBrowser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TuleapBrowser'</code><div>
+<div><div>
+ Specify the HTTPS URL for the Tuleap Git repository so that links to changes can be automatically generated by Jenkins.
+</div></div>
+<ul><li><code>repositoryUrl : String</code>
+<div><div>
+ The URL is the web URL of the Tuleap Git repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewGitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in ViewGit (e.g. scripts, scuttle etc. from <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>gitTool : String</code>
+<div><p>Absolute path to the git executable.</p>
+<p>This is <strong>different</strong> from other Jenkins tool definitions. Rather than providing the directory that contains the executable, you <strong>must provide the complete path to the executable</strong>. Setting '<code>/usr/bin/git</code>' would be correct, while setting '<code>/usr/bin/</code>' is not correct.</p></div>
+
+</li>
+<li><code>extensions</code>
+<div><div>
+ <p>Extensions add new behavior or modify existing plugin behavior for different uses. Extensions help users more precisely tune plugin behavior to meet their needs.</p>
+ <p>Extensions include:</p>
+ <ul>
+  <li><strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace. The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.</li>
+  <li><strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent. The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.</li>
+  <li><strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.</li>
+  <li><strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.</li>
+  <li><strong>Build initiation extensions</strong> control the conditions that start a build. They can ignore notifications of a change or force a deeper evaluation of the commits when polling.</li>
+  <li><strong>Merge extensions</strong> can optionally merge changes from other branches into the current branch of the agent workspace. They control the source branch for the merge and the options applied to the merge.</li>
+ </ul>
+ <p></p>
+</div></div>
+
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AuthorInChangelog'</code><div>
+<div><div>
+ The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets. If this option is selected, the Git commit's "Author" value would be used instead.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'BuildChooserSetting'</code><div>
+<div><div>
+ When you are interested in using a job to build multiple heads (most typically multiple branches), you can choose how Jenkins choose what branches to build in what order. 
+ <p>This extension point in Jenkins is used by many other plugins to control the job to build specific commits. When you activate those plugins, you may see them installing a custom strategy here.</p>
+</div></div>
+<ul><li><code>buildChooser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AlternativeBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'AncestryBuildChooser'</code><div>
+<ul><li><code>maximumAgeInDays : int</code>
+</li>
+<li><code>ancestorCommitSha1 : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DefaultBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'DeflakeGitBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GerritTriggerBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'InverseBuildChooser'</code><div>
+<ul></ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'BuildSingleRevisionOnly'</code><div>
+<div><div>
+ Disable scheduling for multiple candidate revisions.<br> If we have 3 branches:<br> ----A--.---.--- B<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br> jenkins would try to build (B) and (C).<br> This behaviour disables this and only builds one of them.<br> It is helpful to reduce the load of the Jenkins infrastructure when the SCM system like Bitbucket or GitHub should decide what commits to build.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ChangelogToBranch'</code><div>
+<div><div>
+ This method calculates the changelog against the specified branch.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>compareRemote : String</code>
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below.
+</div></div>
+
+</li>
+<li><code>compareTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to compare against.
+</div></div>
+
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CheckoutOption'</code><div>
+<ul><li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for checkout.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanBeforeCheckout'</code><div>
+<div><div>
+ Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanCheckout'</code><div>
+<div><div>
+ Clean up the workspace after every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneOption'</code><div>
+<ul><li><code>shallow : boolean</code>
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code>
+<div><div>
+ Deselect this to perform a clone without tags, saving time and disk space when you just want to access what is specified by the refspec.
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for clone and fetch operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>honorRefspec : boolean</code> (optional)
+<div><div>
+ Perform initial clone using the refspec defined for the repository. This can save time, data transfer and disk space when you only need to access the references specified by the refspec.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CodeCommitURLHelper'</code><div>
+<ul><li><code>credentialId : String</code>
+<div><div>
+ <p>OPTIONAL: Select the credentials to use.<br> If not specified, defaults to the <a href="http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain" rel="nofollow"> DefaultAWSCredentialsProviderChain </a> behaviour - <b>*FROM THE JENKINS INSTANCE*</b></p>
+ <p>In the latter case, usage of IAM Role Profiles seems not to work, thus relying on environment variables / system properties or the ~/.aws/credentials file, thus not recommended.</p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DisableRemotePoll'</code><div>
+<div><div>
+ Git plugin uses git ls-remote polling mechanism by default when configured with a single branch (no wildcards!). This compare the latest built commit SHA with the remote branch without cloning a local copy of the repo.<br><br> If you don't want to / can't use this.<br><br> If this option is selected, polling will require a workspace and might trigger unwanted builds (see <a href="https://issues.jenkins.io/browse/JENKINS-10131" rel="nofollow">JENKINS-10131</a>).
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromChangeSet'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromPoll'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GitLFSPull'</code><div>
+<div><div>
+ Enable <a href="https://git-lfs.github.com/" rel="nofollow">git large file support</a> for the workspace by pulling large files after the checkout completes. Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'GitSCMChecksExtension'</code><div>
+<ul><li><code>verboseConsoleLog : boolean</code> (optional)
+<div><div>
+ If this option is checked, verbose log will be output to build console; the verbose log is useful for debugging the publisher creation.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCMStatusChecksExtension'</code><div>
+<ul><li><code>name : String</code> (optional)
+</li>
+<li><code>skip : boolean</code> (optional)
+</li>
+<li><code>skipProgressUpdates : boolean</code> (optional)
+</li>
+<li><code>suppressLogs : boolean</code> (optional)
+</li>
+<li><code>unstableBuildNeutral : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'GitTagMessageExtension'</code><div>
+<div><div>
+ If the revision checked out has a git tag associated with it, the tag name will be exported during the build as <strong>GIT_TAG_NAME</strong>. <br> If a message was specified when creating the tag, then that message will be exported during the build as the <strong>GIT_TAG_MESSAGE</strong> environment variable. <br> If no tag message was specified, the commit message will be used. <br> If you ticked the <strong>Use most recent tag</strong> option, and the revision checked out has no git tag associated with it, the parent commits will be searched for a git tag, and the rules stated above will apply to the first parent commit with a git tag. 
+ <p></p> If the revision has more than one tag associated with it, only the most recent tag will be taken into account, <strong>unless</strong> the refspec contains "refs/tags/" — i.e. builds are only triggered when certain tag names or patterns are matched — in which case the exact tag name that triggered the build will be used, even if it's not the most recent tag for this commit. <br> For this reason, if you're not using a tag-specific refspec but you <em>are</em> using the "Create a tag for every build" behaviour, you should make sure that the build-tagging behaviour is configured to run <em>after</em> this "export git tag message" behaviour. 
+ <p></p> Tag and commit messages which span multiple lines are no problem, though only the first 10000 lines of a tag's message will be exported.
+</div></div>
+<ul><li><code>useMostRecentTag : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IgnoreNotifyCommit'</code><div>
+<div><div>
+ If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository matches or not.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'LocalBranch'</code><div>
+<div><div>
+ If given, checkout the revision to build as HEAD on this branch. 
+ <p>If selected, and its value is an empty string or "**", then the branch name is computed from the remote branch without the origin. In that case, a remote branch origin/master will be checked out to a local branch named master, and a remote branch origin/develop/new-feature will be checked out to a local branch named develop/newfeature.</p>
+ <p>Please note that this has not been tested with submodules.</p>
+</div></div>
+<ul><li><code>localBranch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MessageExclusion'</code><div>
+<ul><li><code>excludedMessage : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct message. 
+ <p></p>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()" rel="nofollow">matching</a>
+ <p></p>
+ <pre>.*\[maven-release-plugin\].*</pre> The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have been committed to the SCM a build will not occur. 
+ <p></p> You can create more complex patterns using embedded flag expressions. 
+ <pre>(?s).*FOO.*</pre> This example will search FOO message in all comment lines.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PathRestriction'</code><div>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
+</div></div>
+<ul><li><code>includedRegions : String</code>
+<div><div>
+ Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. An empty list implies that everything is included. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that a build will only occur, if html/jpeg/gif files have been committed to the SCM. Exclusions take precedence over inclusions, if there is an overlap between included and excluded regions.
+</div></div>
+
+</li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PerBuildTag'</code><div>
+<div><div>
+ Create a tag in the workspace for every build to unambiguously mark the commit that was built. You can combine this with Git publisher to push the tags to the remote repository.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'PreBuildMerge'</code><div>
+<div><div>
+ These options allow you to perform a merge to a particular branch before building. For example, you could specify an integration branch to be built, and to merge to master. In this scenario, on every change of integration, Jenkins will perform a merge with the master branch, and try to perform a build if the merge is successful. It then may push the merge back to the remote repository if the Git Push post-build action is selected.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>mergeTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to merge to, such as <code>master</code>.
+</div></div>
+
+</li>
+<li><code>fastForwardMode</code> (optional)
+<div><div>
+ Merge fast-forward mode selection.<br> The default, --ff, gracefully falls back to a merge commit when required.<br> For more information, see the <a href="http://git-scm.com/docs/git-merge" rel="nofollow">Git Merge Documentation</a>
+</div></div>
+
+<ul><li><b>Values:</b> <code>FF</code>, <code>FF_ONLY</code>, <code>NO_FF</code></li></ul></li>
+<li><code>mergeRemote : String</code> (optional)
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below. If left blank, it'll default to the name of the first repository configured above.
+</div></div>
+
+</li>
+<li><code>mergeStrategy</code> (optional)
+<div><div>
+ Merge strategy selection. <strong>This feature is not fully implemented in JGIT.</strong>
+</div></div>
+
+<ul><li><b>Values:</b> <code>DEFAULT</code>, <code>RESOLVE</code>, <code>RECURSIVE</code>, <code>OCTOPUS</code>, <code>OURS</code>, <code>SUBTREE</code>, <code>RECURSIVE_THEIRS</code></li></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>pretestedIntegration</code><div>
+<ul><li><code>gitIntegrationStrategy</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>accumulated</code><div>
+<div><h2>Accumulated Commit Strategy</h2>
+<div>
+ This strategy merges your commits with the --no-ff switch
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>ffonly</code><div>
+<div><h2>Fast Forward only (--ff-only) Strategy</h2>
+<div>
+ This strategy fast-forward only using the --ff-only switch - or fails
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>squash</code><div>
+<div><h2>Squashed Commit Strategy</h2>
+<div>
+ This strategy squashes all your commit on a given branch with the --squash option
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>integrationBranch : String</code>
+<div><h3>What to specify</h3>
+<p>The branch name must match your integration branch name. <b>No trailing slash.</b></p>
+<h3>Merge is performed the following way</h3>
+<h5>Squash commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge --squash &lt;Branch matched by git&gt;
+            git commit -C &lt;Branch matched by git&gt;</pre>
+<h5>Accumulated commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge -m &lt;commitMsg&gt; &lt;Branch matched by git&gt; --no-ff</pre>
+<h3>When changes are pushed to the integration branch?</h3>
+<p>Changes are only ever pushed when the build results is SUCCESS</p>
+<pre>            git push &lt;Repository name&gt; &lt;Branch name&gt;</pre></div>
+
+</li>
+<li><code>repoName : String</code>
+<div><div>
+ <h3>What to specify</h3>
+ <p>The repository name. In git the repository is always the name of the remote. So if you have specified a repository name in your Git configuration. You need to specify the exact same name here, otherwise no integration will be performed. We do the merge based on this.</p>
+ <p><b>No trailing slash on repository name.</b></p>
+ <p><span>Remember to specify this when working with NAMED repositories in Git</span></p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PruneStaleBranch'</code><div>
+<div><div>
+ Run "git remote prune" for each remote, to prune obsolete local branches.
+</div></div>
+<ul></ul></div></li>
+<li><code>pruneTags</code><div>
+<ul><li><code>pruneTags : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RelativeTargetDirectory'</code><div>
+<ul><li><code>relativeTargetDir : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where the Git repository will be checked out. If left empty, the workspace root itself will be used. 
+ <p>This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted). Jenkins Pipeline already provides standard techniques for checkout to a subdirectory. Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" rel="nofollow">ws</a> and <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" rel="nofollow">dir</a> in Jenkins Pipeline rather than this extension.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmName'</code><div>
+<div><div>
+ <p>Unique name for this SCM. Needed when using Git within the Multi SCM plugin.</p>
+</div></div>
+<ul><li><code>name : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SparseCheckoutPaths'</code><div>
+<div><div>
+ <p>Specify the paths that you'd like to sparse checkout. This may be used for saving space (Think about a reference repository). Be sure to use a recent version of Git, at least above 1.7.10</p>
+</div></div>
+<ul><li><code>sparseCheckoutPaths</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>path : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'SubmoduleOption'</code><div>
+<ul><li><code>disableSubmodules : boolean</code>
+<div><div>
+ By disabling support for submodules you can still keep using basic git plugin functionality and just have Jenkins to ignore submodules completely as if they didn't exist.
+</div></div>
+
+</li>
+<li><code>recursiveSubmodules : boolean</code>
+<div><div>
+ Retrieve all submodules recursively (uses '--recursive' option which requires git&gt;=1.6.5)
+</div></div>
+
+</li>
+<li><code>trackingSubmodules : boolean</code>
+<div><div>
+ Retrieve the tip of the configured branch in .gitmodules (Uses '--remote' option which requires git&gt;=1.8.2)
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.<br> To prepare a reference folder with multiple subprojects, create a bare git repository and add all the remote urls then perform a fetch:<br>
+ <pre>  git init --bare
+  git remote add SubProject1 https://gitrepo.com/subproject1
+  git remote add SubProject2 https://gitrepo.com/subproject2
+  git fetch --all
+  </pre>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for submodules operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>parentCredentials : boolean</code>
+<div><div>
+ Use credentials from the default remote of the parent project.
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>shallow : boolean</code> (optional)
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>threads : int</code> (optional)
+<div><div>
+ Specify the number of threads that will be used to update submodules.<br> If unspecified, the command line git default thread count is used.<br>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserExclusion'</code><div>
+<ul><li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well. 
+ <p></p>Each exclusion uses exact string comparison and must be separated by a new line. User names are only excluded if they exactly match one of the names in this list. 
+ <p></p>
+ <pre>auto_build_user</pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserIdentity'</code><div>
+<ul><li><code>name : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+<li><code>email : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WipeWorkspace'</code><div>
+<div><div>
+ Delete the contents of the workspace before building, ensuring a fully fresh workspace.
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>doGenerateSubmoduleConfigurations : boolean</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value and always uses <code>false</code> as its value.</p></div>
+
+</li>
+<li><code>submoduleCfg</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value(s) and always uses empty values.</p></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>submoduleName : String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+</li>
+<li><code>branches : Array / List of String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+<ul></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'HarvestSCM'</code><div>
+<ul><li><code>broker : String</code>
+</li>
+<li><code>passwordFile : String</code>
+</li>
+<li><code>userId : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>projectName : String</code>
+</li>
+<li><code>state : String</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>clientPath : String</code>
+</li>
+<li><code>processName : String</code>
+</li>
+<li><code>recursiveSearch : String</code>
+</li>
+<li><code>useSynchronize : boolean</code>
+</li>
+<li><code>extraOptions : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'IntegritySCM'</code><div>
+<div><div>
+ Checks out source code from "Windchill RV&amp;S for Configuration Management" repositories
+</div></div>
+<ul><li><code>serverConfig : String</code>
+</li>
+<li><code>configPath : String</code>
+</li>
+<li><code>configurationName : String</code>
+</li>
+<li><code>CPBasedMode : boolean</code> (optional)
+</li>
+<li><code>alternateWorkspace : String</code> (optional)
+</li>
+<li><code>browser</code> (optional)
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'IntegrityWebUI'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the PTC Windchill RV&amp;S Configuration Management server.<br> For example: http://hostname:7001<br> This value is optional and is used as an override to the URL detected in the Windchill RV&amp;S Change Log.
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>checkoutThreadPoolSize : int</code> (optional)
+</li>
+<li><code>checkoutThreadTimeout : int</code> (optional)
+</li>
+<li><code>checkpointBeforeBuild : boolean</code> (optional)
+</li>
+<li><code>checkpointLabel : String</code> (optional)
+</li>
+<li><code>cleanCopy : boolean</code> (optional)
+</li>
+<li><code>deleteNonMembers : boolean</code> (optional)
+</li>
+<li><code>excludeList : String</code> (optional)
+</li>
+<li><code>fetchChangedWorkspaceFiles : boolean</code> (optional)
+</li>
+<li><code>includeList : String</code> (optional)
+</li>
+<li><code>lineTerminator : String</code> (optional)
+</li>
+<li><code>localClient : boolean</code> (optional)
+</li>
+<li><code>password : String</code> (optional)
+</li>
+<li><code>restoreTimestamp : boolean</code> (optional)
+</li>
+<li><code>sandboxScope : String</code> (optional)
+</li>
+<li><code>skipAuthorInfo : boolean</code> (optional)
+</li>
+<li><code>userName : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IspwConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>serverConfig : String</code>
+</li>
+<li><code>serverStream : String</code>
+</li>
+<li><code>serverApplication : String</code>
+</li>
+<li><code>serverLevel : String</code>
+</li>
+<li><code>levelOption : String</code>
+</li>
+<li><code>componentType : String</code>
+</li>
+<li><code>folderName : String</code>
+</li>
+<li><code>ispwDownloadAll : boolean</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+<li><code>ispwDownloadIncl : boolean</code>
+</li>
+<li><code>ispwDownloadWithCompileOnly : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'IspwContainerConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>serverConfig : String</code>
+</li>
+<li><code>containerName : String</code>
+</li>
+<li><code>containerType : String</code>
+</li>
+<li><code>serverLevel : String</code>
+</li>
+<li><code>componentType : String</code>
+</li>
+<li><code>ispwDownloadAll : boolean</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+<li><code>ispwDownloadIncl : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MercurialSCM'</code><div>
+<ul><li><code>source : String</code>
+<div><div>
+ Specify the repository to track. This can be URL or a local file path. If you are specifying HTTP credentials, do <em>not</em> include a username in the URL.
+</div></div>
+
+</li>
+<li><code>browser</code> (optional)
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEye'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository, such as: http://www.example.org/browse/hg/
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GoogleCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="http://code.google.com/p/PROJECTNAME/source/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'HgWeb'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://www.mercurial-scm.org/repo/hg/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Kallithea'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnHG'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://acme.kilnhg.com/Repo/Repositories/Group/PROJECTNAME" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCodeLegacy'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManager'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <code>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</code>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>clean : boolean</code> (optional)
+<div><div>
+ When this option is checked, each build will wipe any local modifications or untracked files in the repository checkout. This is often a convenient way to ensure that a build is not using any artifacts from earlier builds.
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code> (optional)
+<div><div>
+ Optional credentials to use when cloning or pulling from the remote repository. Supports username/password with HTTP(S) URLs, and SSH private key with SSH URLs.
+</div></div>
+
+</li>
+<li><code>disableChangeLog : boolean</code> (optional)
+<div><div>
+ When checked, Hudson will not calculate the Mercurial changelog for each build. Disabling the changelog can decrease the amount of time needed to update a very large repository.
+</div></div>
+
+</li>
+<li><code>installation : String</code> (optional)
+</li>
+<li><code>modules : String</code> (optional)
+<div><div>
+ Reduce unnecessary builds by specifying a comma or space delimited list of "modules" within the repository. A module is a directory name within the repository that this project lives in. If this field is set, changes outside the specified modules will not trigger a build (even though the whole repository is checked out anyway due to the Mercurial limitation.)
+</div></div>
+
+</li>
+<li><code>revision : String</code> (optional)
+<div><div>
+ Specify the branch or tag name you would like to track. (If you do not type anything, the default value is the <code>default</code> branch.)
+</div></div>
+
+</li>
+<li><code>revisionType</code> (optional)
+<div><div>
+ Specify the kind of revision you expect Jenkins to update your working copy to.
+</div></div>
+
+<ul><li><b>Values:</b> <code>BRANCH</code>, <code>TAG</code>, <code>CHANGESET</code>, <code>REVSET</code></li></ul></li>
+<li><code>subdir : String</code> (optional)
+<div><div>
+ If not empty, check out the Mercurial repository into this subdirectory of the job's workspace. For example: <code>my/sources</code> (use forward slashes). If changing this entry, you probably want to clean the workspace first.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'MergeBotUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'MultiSCM'</code><div>
+<ul><li><code>scmList</code>
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AWSCodePipelineSCM'</code><div>
+<ul><li><code>name : String</code>
+</li>
+<li><code>clearWorkspace : boolean</code>
+</li>
+<li><code>region : String</code>
+</li>
+<li><code>awsAccessKey : String</code>
+<div><div>
+ <p>In order to integrate with AWS CodePipeline, you must authorize access to the pipeline and its related artifacts. If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials. This is the preferred method. In all other cases, you can store AWS credentials in these fields. You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted. For more information, see <a rel="nofollow">AWS CodePipeline Integration for Other Products and Services</a>.</p>
+</div></div>
+
+</li>
+<li><code>awsSecretKey : String</code>
+<div><div>
+ <p>&gt;In order to integrate with AWS CodePipeline, you must authorize access to the pipeline and its related artifacts. If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials. This is the preferred method. In all other cases, you can store AWS credentials in these fields. You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted. For more information, see <a rel="nofollow">AWS CodePipeline Integration for Other Products and Services</a>.</p>
+</div></div>
+
+</li>
+<li><code>proxyHost : String</code>
+<div><div>
+ <p>You might need a proxy host address if you are hosting Jenkins on a private network. The proxy name can be an IP address or DNS address. The AWS CodePipeline Plugin for Jenkins requires internet access. If access is not configured, you might see errors in the AWS CodePipeline Polling Log.</p>
+</div></div>
+
+</li>
+<li><code>proxyPort : String</code>
+<div><div>
+ <p>You might need a proxy port for your proxy host address if you are hosting Jenkins on a private network. The proxy port is a number, might be on port 8080, 3128, or 8443, depending on your network protocols and security settings. If access is not configured, you might see errors in the AWS CodePipeline Polling Log.</p>
+</div></div>
+
+</li>
+<li><code>category : String</code>
+<div><div>
+ <p>This is the category of the action type in AWS CodePipeline, and is usually either Build or Test. To see an example usage, see <a rel="nofollow">Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+</div></div>
+
+</li>
+<li><code>provider : String</code>
+<div><div>
+ <p>This is the provider name of the action type in AWS CodePipeline. You must provide this exact string when adding an action for Jenkins in AWS CodePipeline. To see an example usage, see <a rel="nofollow">Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+</div></div>
+
+</li>
+<li><code>version : String</code>
+<div><div>
+ <p>Leave the default as 1.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>accurev</code><div>
+<ul><li><code>depot : String</code>
+</li>
+<li><code>stream : String</code>
+</li>
+<li><code>serverName : String</code> (optional)
+</li>
+<li><code>serverUUID : String</code> (optional)
+</li>
+<li><code>wspaceORreftree : String</code> (optional)
+</li>
+<li><code>accurevTool : String</code> (optional)
+</li>
+<li><code>cleanreftree : boolean</code> (optional)
+</li>
+<li><code>directoryOffset : String</code> (optional)
+</li>
+<li><code>dontPopContent : boolean</code> (optional)
+</li>
+<li><code>filterForPollSCM : String</code> (optional)
+</li>
+<li><code>ignoreStreamParent : boolean</code> (optional)
+</li>
+<li><code>reftree : String</code> (optional)
+</li>
+<li><code>snapshotNameFormat : String</code> (optional)
+</li>
+<li><code>subPath : String</code> (optional)
+</li>
+<li><code>subPathOnly : boolean</code> (optional)
+</li>
+<li><code>synctime : boolean</code> (optional)
+</li>
+<li><code>useSnapshot : boolean</code> (optional)
+</li>
+<li><code>workspace : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'BazaarSCM'</code><div>
+<ul><li><code>source : String</code>
+</li>
+<li><code>cleantree : boolean</code>
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'Loggerhead'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Loggerhead is a web-based interface for <a href="http://bazaar-vcs.org" rel="nofollow">Bazaar </a> branches. It is used by <a href="https://launchpad.net" rel="nofollow">Launchpad</a>, so if your code is hosted on Launchpad, you are using Loggerhead.
+</div>
+<div>
+ The repository browser URL for the root of the project. For example, a Launchpad project called myproject would use http://bazaar.launchpad.net/~myteam/myproject/mybranch.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ The repository browser URL for the root of the project. For example, the OpenGrok project would use http://src.opensolaris.org/source/.
+</div></div>
+
+</li>
+<li><code>rootModule : String</code>
+<div><div>
+ Specify the root Bazaar module that this OpenGrok monitors. For example, for http://src.opensolaris.org/source/xref/opengrok/trunk/, this field would be opengrok/trunk/ because it displays the directory "/opengrok/trunk/".
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>checkout : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'BitKeeperSCM'</code><div>
+<ul><li><code>parent : String</code>
+</li>
+<li><code>localRepository : String</code>
+</li>
+<li><code>usePull : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+</li>
+</ul></div></li>
+<li><code>BbS</code><div>
+<ul><li><code>id : String</code>
+</li>
+<li><code>branches</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+<div><div>
+ <p>Specify the branches if you'd like to track a specific branch in a repository. If left blank, all branches will be examined for changes and built.</p>
+ <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch is unambiguous.</p>
+ <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented with a full path the plugin will only use the part of the string right of the last slash. Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+ <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>), you'll need to specify the origin repository in the branch names to make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+ <p>Possible options:</p>
+ <ul>
+  <li><strong><code>&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>master</code>, <code>feature1</code>, ...</li>
+  <li><strong><code>refs/heads/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...</li>
+  <li><strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one.<br> Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>origin/master</code></li>
+  <li><strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>remotes/origin/master</code></li>
+  <li><strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/remotes/origin/master</code></li>
+  <li><strong><code>&lt;tagName&gt;</code></strong><br> This does not work since the tag will not be recognized as tag.<br> Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br> E.g. <code>git-2.3.0</code></li>
+  <li><strong><code>refs/tags/&lt;tagName&gt;</code></strong><br> Tracks/checks out the specified tag.<br> E.g. <code>refs/tags/git-2.3.0</code></li>
+  <li><strong><code>&lt;commitId&gt;</code></strong><br> Checks out the specified commit.<br> E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...</li>
+  <li><strong><code>${ENV_VARIABLE}</code></strong><br> It is also possible to use environment variables. In this case the variables are evaluated and the result is used as described above.<br> E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...</li>
+  <li><strong><code>&lt;Wildcards&gt;</code></strong><br> The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>. In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.</li>
+  <li><strong><code>:&lt;regular expression&gt;</code></strong><br> The syntax is of the form: <code>:regexp</code>. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.<br> Examples:<br>
+   <ul>
+    <li><code>:^(?!(origin/prefix)).*</code>
+     <ul>
+      <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+      <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+     </ul></li>
+    <li><code>:origin/release-\d{8}</code>
+     <ul>
+      <li>matches: <code>origin/release-20150101</code></li>
+      <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+     </ul></li>
+    <li><code>:^(?!origin/master$|origin/develop$).*</code>
+     <ul>
+      <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+      <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+     </ul></li>
+   </ul></li>
+ </ul>
+ <p></p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>When running a job, Jenkins requires credentials to authenticate with Bitbucket Server. For example, to checkout the source code for builds. To do this, it needs credentials with access to the projects and repositories you want it to build from.</p>
+ <p>You can provide Jenkins with credentials here by:</p>
+ <ul>
+  <li>selecting credentials from the list</li>
+  <li>adding credentials as a <strong>Username with password</strong> (for the password, you can enter a Bitbucket Server password or a Bitbucket Server <a href="https://confluence.atlassian.com/x/a97-Nw" rel="nofollow">personal access token</a>)</li>
+ </ul>
+ <p>In addition, you can provide Jenkins with SSH credentials below. If you do, Jenkins will use them for clone operations instead of the credentials you select here.</p>
+</div></div>
+
+</li>
+<li><code>sshCredentialsId : String</code>
+<div><div>
+ <p>If specified, Jenkins will use these credentials to check out the source code for builds. If no SSH credentials are specified, Jenkins will use the basic credentials instead.</p>
+ <p>To provide Jenkins with SSH credentials, you can:</p>
+ <ul>
+  <li>choose credentials from the list</li>
+  <li>add credentials as a <strong>SSH Username with private key</strong> (the username must be "git")</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>extensions</code>
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AuthorInChangelog'</code><div>
+<div><div>
+ The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets. If this option is selected, the Git commit's "Author" value would be used instead.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'BuildChooserSetting'</code><div>
+<div><div>
+ When you are interested in using a job to build multiple heads (most typically multiple branches), you can choose how Jenkins choose what branches to build in what order. 
+ <p>This extension point in Jenkins is used by many other plugins to control the job to build specific commits. When you activate those plugins, you may see them installing a custom strategy here.</p>
+</div></div>
+<ul><li><code>buildChooser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AlternativeBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'AncestryBuildChooser'</code><div>
+<ul><li><code>maximumAgeInDays : int</code>
+</li>
+<li><code>ancestorCommitSha1 : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DefaultBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'DeflakeGitBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GerritTriggerBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'InverseBuildChooser'</code><div>
+<ul></ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'BuildSingleRevisionOnly'</code><div>
+<div><div>
+ Disable scheduling for multiple candidate revisions.<br> If we have 3 branches:<br> ----A--.---.--- B<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br> jenkins would try to build (B) and (C).<br> This behaviour disables this and only builds one of them.<br> It is helpful to reduce the load of the Jenkins infrastructure when the SCM system like Bitbucket or GitHub should decide what commits to build.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ChangelogToBranch'</code><div>
+<div><div>
+ This method calculates the changelog against the specified branch.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>compareRemote : String</code>
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below.
+</div></div>
+
+</li>
+<li><code>compareTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to compare against.
+</div></div>
+
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CheckoutOption'</code><div>
+<ul><li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for checkout.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanBeforeCheckout'</code><div>
+<div><div>
+ Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanCheckout'</code><div>
+<div><div>
+ Clean up the workspace after every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneOption'</code><div>
+<ul><li><code>shallow : boolean</code>
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code>
+<div><div>
+ Deselect this to perform a clone without tags, saving time and disk space when you just want to access what is specified by the refspec.
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for clone and fetch operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>honorRefspec : boolean</code> (optional)
+<div><div>
+ Perform initial clone using the refspec defined for the repository. This can save time, data transfer and disk space when you only need to access the references specified by the refspec.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CodeCommitURLHelper'</code><div>
+<ul><li><code>credentialId : String</code>
+<div><div>
+ <p>OPTIONAL: Select the credentials to use.<br> If not specified, defaults to the <a href="http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain" rel="nofollow"> DefaultAWSCredentialsProviderChain </a> behaviour - <b>*FROM THE JENKINS INSTANCE*</b></p>
+ <p>In the latter case, usage of IAM Role Profiles seems not to work, thus relying on environment variables / system properties or the ~/.aws/credentials file, thus not recommended.</p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DisableRemotePoll'</code><div>
+<div><div>
+ Git plugin uses git ls-remote polling mechanism by default when configured with a single branch (no wildcards!). This compare the latest built commit SHA with the remote branch without cloning a local copy of the repo.<br><br> If you don't want to / can't use this.<br><br> If this option is selected, polling will require a workspace and might trigger unwanted builds (see <a href="https://issues.jenkins.io/browse/JENKINS-10131" rel="nofollow">JENKINS-10131</a>).
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromChangeSet'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromPoll'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GitLFSPull'</code><div>
+<div><div>
+ Enable <a href="https://git-lfs.github.com/" rel="nofollow">git large file support</a> for the workspace by pulling large files after the checkout completes. Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'GitSCMChecksExtension'</code><div>
+<ul><li><code>verboseConsoleLog : boolean</code> (optional)
+<div><div>
+ If this option is checked, verbose log will be output to build console; the verbose log is useful for debugging the publisher creation.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCMStatusChecksExtension'</code><div>
+<ul><li><code>name : String</code> (optional)
+</li>
+<li><code>skip : boolean</code> (optional)
+</li>
+<li><code>skipProgressUpdates : boolean</code> (optional)
+</li>
+<li><code>suppressLogs : boolean</code> (optional)
+</li>
+<li><code>unstableBuildNeutral : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'GitTagMessageExtension'</code><div>
+<div><div>
+ If the revision checked out has a git tag associated with it, the tag name will be exported during the build as <strong>GIT_TAG_NAME</strong>. <br> If a message was specified when creating the tag, then that message will be exported during the build as the <strong>GIT_TAG_MESSAGE</strong> environment variable. <br> If no tag message was specified, the commit message will be used. <br> If you ticked the <strong>Use most recent tag</strong> option, and the revision checked out has no git tag associated with it, the parent commits will be searched for a git tag, and the rules stated above will apply to the first parent commit with a git tag. 
+ <p></p> If the revision has more than one tag associated with it, only the most recent tag will be taken into account, <strong>unless</strong> the refspec contains "refs/tags/" — i.e. builds are only triggered when certain tag names or patterns are matched — in which case the exact tag name that triggered the build will be used, even if it's not the most recent tag for this commit. <br> For this reason, if you're not using a tag-specific refspec but you <em>are</em> using the "Create a tag for every build" behaviour, you should make sure that the build-tagging behaviour is configured to run <em>after</em> this "export git tag message" behaviour. 
+ <p></p> Tag and commit messages which span multiple lines are no problem, though only the first 10000 lines of a tag's message will be exported.
+</div></div>
+<ul><li><code>useMostRecentTag : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IgnoreNotifyCommit'</code><div>
+<div><div>
+ If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository matches or not.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'LocalBranch'</code><div>
+<div><div>
+ If given, checkout the revision to build as HEAD on this branch. 
+ <p>If selected, and its value is an empty string or "**", then the branch name is computed from the remote branch without the origin. In that case, a remote branch origin/master will be checked out to a local branch named master, and a remote branch origin/develop/new-feature will be checked out to a local branch named develop/newfeature.</p>
+ <p>Please note that this has not been tested with submodules.</p>
+</div></div>
+<ul><li><code>localBranch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MessageExclusion'</code><div>
+<ul><li><code>excludedMessage : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct message. 
+ <p></p>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()" rel="nofollow">matching</a>
+ <p></p>
+ <pre>.*\[maven-release-plugin\].*</pre> The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have been committed to the SCM a build will not occur. 
+ <p></p> You can create more complex patterns using embedded flag expressions. 
+ <pre>(?s).*FOO.*</pre> This example will search FOO message in all comment lines.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PathRestriction'</code><div>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
+</div></div>
+<ul><li><code>includedRegions : String</code>
+<div><div>
+ Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. An empty list implies that everything is included. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that a build will only occur, if html/jpeg/gif files have been committed to the SCM. Exclusions take precedence over inclusions, if there is an overlap between included and excluded regions.
+</div></div>
+
+</li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PerBuildTag'</code><div>
+<div><div>
+ Create a tag in the workspace for every build to unambiguously mark the commit that was built. You can combine this with Git publisher to push the tags to the remote repository.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'PreBuildMerge'</code><div>
+<div><div>
+ These options allow you to perform a merge to a particular branch before building. For example, you could specify an integration branch to be built, and to merge to master. In this scenario, on every change of integration, Jenkins will perform a merge with the master branch, and try to perform a build if the merge is successful. It then may push the merge back to the remote repository if the Git Push post-build action is selected.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>mergeTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to merge to, such as <code>master</code>.
+</div></div>
+
+</li>
+<li><code>fastForwardMode</code> (optional)
+<div><div>
+ Merge fast-forward mode selection.<br> The default, --ff, gracefully falls back to a merge commit when required.<br> For more information, see the <a href="http://git-scm.com/docs/git-merge" rel="nofollow">Git Merge Documentation</a>
+</div></div>
+
+<ul><li><b>Values:</b> <code>FF</code>, <code>FF_ONLY</code>, <code>NO_FF</code></li></ul></li>
+<li><code>mergeRemote : String</code> (optional)
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below. If left blank, it'll default to the name of the first repository configured above.
+</div></div>
+
+</li>
+<li><code>mergeStrategy</code> (optional)
+<div><div>
+ Merge strategy selection. <strong>This feature is not fully implemented in JGIT.</strong>
+</div></div>
+
+<ul><li><b>Values:</b> <code>DEFAULT</code>, <code>RESOLVE</code>, <code>RECURSIVE</code>, <code>OCTOPUS</code>, <code>OURS</code>, <code>SUBTREE</code>, <code>RECURSIVE_THEIRS</code></li></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>pretestedIntegration</code><div>
+<ul><li><code>gitIntegrationStrategy</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>accumulated</code><div>
+<div><h2>Accumulated Commit Strategy</h2>
+<div>
+ This strategy merges your commits with the --no-ff switch
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>ffonly</code><div>
+<div><h2>Fast Forward only (--ff-only) Strategy</h2>
+<div>
+ This strategy fast-forward only using the --ff-only switch - or fails
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>squash</code><div>
+<div><h2>Squashed Commit Strategy</h2>
+<div>
+ This strategy squashes all your commit on a given branch with the --squash option
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>integrationBranch : String</code>
+<div><h3>What to specify</h3>
+<p>The branch name must match your integration branch name. <b>No trailing slash.</b></p>
+<h3>Merge is performed the following way</h3>
+<h5>Squash commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge --squash &lt;Branch matched by git&gt;
+            git commit -C &lt;Branch matched by git&gt;</pre>
+<h5>Accumulated commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge -m &lt;commitMsg&gt; &lt;Branch matched by git&gt; --no-ff</pre>
+<h3>When changes are pushed to the integration branch?</h3>
+<p>Changes are only ever pushed when the build results is SUCCESS</p>
+<pre>            git push &lt;Repository name&gt; &lt;Branch name&gt;</pre></div>
+
+</li>
+<li><code>repoName : String</code>
+<div><div>
+ <h3>What to specify</h3>
+ <p>The repository name. In git the repository is always the name of the remote. So if you have specified a repository name in your Git configuration. You need to specify the exact same name here, otherwise no integration will be performed. We do the merge based on this.</p>
+ <p><b>No trailing slash on repository name.</b></p>
+ <p><span>Remember to specify this when working with NAMED repositories in Git</span></p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PruneStaleBranch'</code><div>
+<div><div>
+ Run "git remote prune" for each remote, to prune obsolete local branches.
+</div></div>
+<ul></ul></div></li>
+<li><code>pruneTags</code><div>
+<ul><li><code>pruneTags : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RelativeTargetDirectory'</code><div>
+<ul><li><code>relativeTargetDir : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where the Git repository will be checked out. If left empty, the workspace root itself will be used. 
+ <p>This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted). Jenkins Pipeline already provides standard techniques for checkout to a subdirectory. Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" rel="nofollow">ws</a> and <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" rel="nofollow">dir</a> in Jenkins Pipeline rather than this extension.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmName'</code><div>
+<div><div>
+ <p>Unique name for this SCM. Needed when using Git within the Multi SCM plugin.</p>
+</div></div>
+<ul><li><code>name : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SparseCheckoutPaths'</code><div>
+<div><div>
+ <p>Specify the paths that you'd like to sparse checkout. This may be used for saving space (Think about a reference repository). Be sure to use a recent version of Git, at least above 1.7.10</p>
+</div></div>
+<ul><li><code>sparseCheckoutPaths</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>path : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'SubmoduleOption'</code><div>
+<ul><li><code>disableSubmodules : boolean</code>
+<div><div>
+ By disabling support for submodules you can still keep using basic git plugin functionality and just have Jenkins to ignore submodules completely as if they didn't exist.
+</div></div>
+
+</li>
+<li><code>recursiveSubmodules : boolean</code>
+<div><div>
+ Retrieve all submodules recursively (uses '--recursive' option which requires git&gt;=1.6.5)
+</div></div>
+
+</li>
+<li><code>trackingSubmodules : boolean</code>
+<div><div>
+ Retrieve the tip of the configured branch in .gitmodules (Uses '--remote' option which requires git&gt;=1.8.2)
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.<br> To prepare a reference folder with multiple subprojects, create a bare git repository and add all the remote urls then perform a fetch:<br>
+ <pre>  git init --bare
+  git remote add SubProject1 https://gitrepo.com/subproject1
+  git remote add SubProject2 https://gitrepo.com/subproject2
+  git fetch --all
+  </pre>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for submodules operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>parentCredentials : boolean</code>
+<div><div>
+ Use credentials from the default remote of the parent project.
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>shallow : boolean</code> (optional)
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>threads : int</code> (optional)
+<div><div>
+ Specify the number of threads that will be used to update submodules.<br> If unspecified, the command line git default thread count is used.<br>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserExclusion'</code><div>
+<ul><li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well. 
+ <p></p>Each exclusion uses exact string comparison and must be separated by a new line. User names are only excluded if they exactly match one of the names in this list. 
+ <p></p>
+ <pre>auto_build_user</pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserIdentity'</code><div>
+<ul><li><code>name : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+<li><code>email : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WipeWorkspace'</code><div>
+<div><div>
+ Delete the contents of the workspace before building, ensuring a fully fresh workspace.
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>gitTool : String</code>
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ <p>Enter the name of the Bitbucket Server project containing the repository you want Jenkins to build from. To find a project, start typing. If it doesn't appear in the search results, the credentials that you've chosen may not have read access to it and you'll need to provide different credentials.</p>
+ <p>To get Jenkins to build from a personal repository, enter a tilde (<code>~</code>) followed by repository owner's username. For example, <code>~jsmith.</code></p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+<div><div>
+ <p>Enter the Bitbucket Server repository you want Jenkins to build from. To find a repository, start typing. If it doesn't appear in the search results, the credentials that you've chosen may not have read access to it and you'll need to provide different credentials.</p>
+ <p>To get Jenkins to build from a personal repository, enter its slug. This is the URL-friendly version of the repository name. For example, a repository called my example repo will have the slug <em>my-example-repo</em>, and you can see this in its URL, https://bitbucketserver.mycompany.com/myproject/my-example-repo.</p>
+</div></div>
+
+</li>
+<li><code>serverId : String</code>
+<div><div>
+ <p>Choose the Bitbucket Server instance containing the repository you want Jenkins to build from. If you can't find your instance, check this plugin's configuration and try again.</p>
+</div></div>
+
+</li>
+<li><code>mirrorName : String</code>
+<div><div>
+ <p>Choose the location that Jenkins should clone from when running this build. This can be the primary server or a mirror if one is available. To see available mirrors, first choose a Bitbucket Server project and repository.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BlameSubversionSCM'</code><div>
+<div><div>
+ <p>if it is false and the build is not triggered by upstream job,</p>
+ <p></p>
+ <p>the plugin will not collect any svn info from upstream job.</p>
+ <p>else the plugin will collect svn info from latest upstream job</p>
+</div></div>
+<ul><li><code>alwaysCollectSVNInfo : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CCUCMScm'</code><div>
+<ul><li><code>loadModule : String</code>
+</li>
+<li><code>newest : boolean</code>
+</li>
+<li><code>mode</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'PollChildMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+<div><div>
+ <p>Check this if you want create a baseline after a completed deliver.</p>
+ <p>This is only applicable for child and sibling poll mode.</p>
+</div></div>
+
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollRebaseMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+<div><div>
+ The component used to figure out the correct baseline to recommend due to the following bug: <br> <a href="http://www-01.ibm.com/support/docview.wss?uid=swg21269043" rel="nofollow">http://www-01.ibm.com/support/docview.wss?uid=swg21269043</a>
+</div></div>
+
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+</li>
+<li><code>excludeList : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSelfMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSiblingMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>createBaseline : boolean</code> (optional)
+<div><div>
+ <p>Check this if you want create a baseline after a completed deliver.</p>
+ <p>This is only applicable for child and sibling poll mode.</p>
+</div></div>
+
+</li>
+<li><code>newest : boolean</code> (optional)
+<div><div>
+ Selects the newest baseline on the stream. Skipping intermediates.
+</div></div>
+
+</li>
+<li><code>useHyperLinkForPolling : boolean</code> (optional)
+<div><div>
+ Instead of using the integration streams default deliver target. Use the value specified in the hyperlink. The hyperlink type to be used can be configured in the global configuration.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PollSubscribeMode'</code><div>
+<ul><li><code>levelToPoll : String</code>
+</li>
+<li><code>componentsToMonitor</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>componentSelection : String</code>
+</li>
+</ul></li>
+<li><code>jobsToMonitor</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>jobname : String</code>
+</li>
+<li><code>ignores : String</code>
+<div><div>
+ A comma seperated list of components which should not be included when checking if the requirements are met. That is to say that not all components are interesting in every job specified.
+</div></div>
+
+</li>
+<li><code>jobName : String</code> (optional)
+<div><div>
+ Specifies the name of the job in which all selected baselines must be present.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>cascadePromotion : boolean</code> (optional)
+</li>
+<li><code>component : String</code> (optional)
+</li>
+<li><code>newest : boolean</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>stream : String</code>
+<div><div>
+ Specify the stream you want to poll for with ClearCase UCM SCM. Syntax: [stream]@[PVOB]
+</div></div>
+
+</li>
+<li><code>treatUnstable : String</code>
+</li>
+<li><code>nameTemplate : String</code>
+</li>
+<li><code>forceDeliver : boolean</code>
+</li>
+<li><code>recommend : boolean</code>
+</li>
+<li><code>makeTag : boolean</code>
+</li>
+<li><code>setDescription : boolean</code>
+</li>
+<li><code>buildProject : String</code>
+</li>
+<li><code>removeViewPrivateFiles : boolean</code>
+</li>
+<li><code>trimmedChangeSet : boolean</code>
+</li>
+<li><code>discard : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CVSSCM'</code><div>
+<ul><li><code>repositories</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>cvsRoot : String</code>
+<div><div>
+ The CVS connection string Jenkins uses to connect to the server. The format is the same as $CVSROOT environment variable (:protocol:user@host:path)
+</div></div>
+
+</li>
+<li><code>passwordRequired : boolean</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryItems</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>location</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'BranchRepositoryLocation'</code><div>
+<ul><li><code>branchName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'HeadRepositoryLocation'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TagRepositoryLocation'</code><div>
+<ul><li><code>tagName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>modules</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remoteName : String</code>
+<div><div>
+ The name of the module in the repository at CVSROOT
+</div></div>
+
+</li>
+<li><code>localName : String</code>
+<div><div>
+ The name to be applied to this module in the local workspace. If this is left blank then the remote module name will be used. This is similar to the 'checkout-as' function available on many CVS clients.
+</div></div>
+
+</li>
+<li><code>projectsetFileName : String</code>
+<div><div>
+ The name of the file in this module to parse for projectset entries.
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+<li><code>excludedRegions</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p>Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 src/main/web/.*\.html
+	 src/main/web/.*\.jpeg
+	 src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p>More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pattern : String</code>
+</li>
+</ul></li>
+<li><code>compressionLevel : int</code>
+</li>
+<li><code>repositoryBrowser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+</ul></li>
+<li><code>canUseUpdate : boolean</code>
+<div><div>
+ If checked, Jenkins will use 'cvs update' whenever possible for builds. This makes a build faster. But this also causes the artifacts from the previous build to remain in the file system when a new build starts, making it not a true clean build.
+</div></div>
+
+</li>
+<li><code>legacy : boolean</code>
+<div><div>
+ Hudson 1.20 and earlier used to create redundant directories inside the workspace. For example, if the CVS module name is "foo/bar", it first created "foo/bar" and then put everything below. With this option checked off, there will be no more such unnecessary intermediate directories. 
+ <p>If you have multiple modules to check out, this option is forced (otherwise they'll overlap.)</p>
+ <p>This affects other path specifiers, such as artifact archivers --- you now specify "build/foo.jar" instead of "foo/build/foo.jar".</p>
+</div></div>
+
+</li>
+<li><code>skipChangeLog : boolean</code>
+<div><div>
+ Prevent the changelog being generated after checkout has completed. This will stop any changes being shown on the changes screen but reduces load on your CVS server.
+</div></div>
+
+</li>
+<li><code>pruneEmptyDirectories : boolean</code>
+<div><div>
+ Remove empty directories after checkout using the CVS '-P' option.
+</div></div>
+
+</li>
+<li><code>disableCvsQuiet : boolean</code>
+<div><div>
+ Instructs CVS to show all logging output. CVS normally runs in quiet mode but this option disables that.
+</div></div>
+
+</li>
+<li><code>cleanOnFailedUpdate : boolean</code>
+<div><div>
+ If the job is configured to use CVS update and the update step fails for any reason then the workspace will be wiped-out and a clean checkout done instead.
+</div></div>
+
+</li>
+<li><code>forceCleanCopy : boolean</code>
+<div><div>
+ If checked, Jenkins will add the 'C' option to the CVS update command to force it to over-write any files with local modifications, rather than attempt a merge or leave them as they are.
+</div></div>
+
+</li>
+<li><code>checkoutCurrentTimestamp : boolean</code>
+<div><div>
+ Advanced option. Should probably be left unchecked. 
+ <p>The build quiet period is designed to assist with CVS checkouts by waiting for a specific period of time without commits. Normally you want the checkout to reflect the time when the quiet period was exited successfully. Select this option if you need to re-enable the legacy behaviour of Jenkins, i.e. using the time that the build started checking out as the timestamp for the checkout operation. Note: enabling this option can result in the quiet period being defeated especially in those cases where the build is not able to start immediately after exiting the quiet period.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ClearCaseSCM'</code><div>
+<ul><li><code>branch : String</code>
+</li>
+<li><code>label : String</code>
+</li>
+<li><code>extractConfigSpec : boolean</code>
+</li>
+<li><code>configSpecFileName : String</code>
+</li>
+<li><code>refreshConfigSpec : boolean</code>
+</li>
+<li><code>refreshConfigSpecCommand : String</code>
+</li>
+<li><code>configSpec : String</code>
+</li>
+<li><code>viewTag : String</code>
+</li>
+<li><code>useupdate : boolean</code>
+</li>
+<li><code>extractLoadRules : boolean</code>
+</li>
+<li><code>loadRules : String</code>
+</li>
+<li><code>useOtherLoadRulesForPolling : boolean</code>
+</li>
+<li><code>loadRulesForPolling : String</code>
+</li>
+<li><code>usedynamicview : boolean</code>
+</li>
+<li><code>viewdrive : String</code>
+</li>
+<li><code>mkviewoptionalparam : String</code>
+</li>
+<li><code>filterOutDestroySubBranchEvent : boolean</code>
+</li>
+<li><code>doNotUpdateConfigSpec : boolean</code>
+</li>
+<li><code>rmviewonrename : boolean</code>
+</li>
+<li><code>excludedRegions : String</code>
+</li>
+<li><code>multiSitePollBuffer : String</code>
+</li>
+<li><code>useTimeRule : boolean</code>
+</li>
+<li><code>createDynView : boolean</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>changeset</code>
+<ul><li><b>Values:</b> <code>ALL</code>, <code>BRANCH</code>, <code>NONE</code>, <code>UPDT</code></li></ul></li>
+<li><code>viewStorage</code>
+<div><p>Three strategies are currently available to manage view storage location.</p>
+<ul>
+ <li><b>Default</b>. This entry doesn't generate any additional argument to the <i>cleartool mkview</i> command. The behaviour will change depending on how your clearcase server is configured.</li>
+ <li><b>Use server storage location</b>. This entry generates a <i>-stgloc</i> argument to the <i>cleartool mkview</i> command.</li>
+ <li><b>Use explicit path</b>. This entry generates a <i>-vws</i> argument to the <i>cleartool mkview</i> command.</li>
+</ul>
+<p></p></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DefaultViewStorage'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ServerViewStorage'</code><div>
+<ul><li><code>assignedLabelString : String</code>
+<div><p>Label expression used to populate view storage location dropdown.</p></div>
+
+</li>
+<li><code>server : String</code>
+<div><p>The view storage location that will be passed to the <i>-stgloc</i> option.<br> The list of available servers is retrieved using <i>cleartool lsstgloc -view</i><br> Note that auto is always available.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SpecificViewStorage'</code><div>
+<ul><li><code>winStorageDir : String</code>
+</li>
+<li><code>unixStorageDir : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'ClearCaseUcmBaselineSCM'</code><div>
+<div><div>
+ When used (and fully set up), this option will display a field at build-time so that the user is able to select a ClearCase UCM baseline from which to download the content for this project.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ClearCaseUcmSCM'</code><div>
+<ul><li><code>stream : String</code>
+</li>
+<li><code>loadrules : String</code>
+</li>
+<li><code>viewTag : String</code>
+</li>
+<li><code>usedynamicview : boolean</code>
+</li>
+<li><code>viewdrive : String</code>
+</li>
+<li><code>mkviewoptionalparam : String</code>
+</li>
+<li><code>filterOutDestroySubBranchEvent : boolean</code>
+</li>
+<li><code>useUpdate : boolean</code>
+</li>
+<li><code>rmviewonrename : boolean</code>
+</li>
+<li><code>excludedRegions : String</code>
+</li>
+<li><code>multiSitePollBuffer : String</code>
+</li>
+<li><code>overrideBranchName : String</code>
+</li>
+<li><code>createDynView : boolean</code>
+</li>
+<li><code>freezeCode : boolean</code>
+</li>
+<li><code>recreateView : boolean</code>
+</li>
+<li><code>allocateViewName : boolean</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>useManualLoadRules : boolean</code>
+</li>
+<li><code>changeset</code>
+<ul><li><b>Values:</b> <code>ALL</code>, <code>BRANCH</code>, <code>NONE</code>, <code>UPDT</code></li></ul></li>
+<li><code>viewStorage</code>
+<div><p>Three strategies are currently available to manage view storage location.</p>
+<ul>
+ <li><b>Default</b>. This entry doesn't generate any additional argument to the <i>cleartool mkview</i> command. The behaviour will change depending on how your clearcase server is configured.</li>
+ <li><b>Use server storage location</b>. This entry generates a <i>-stgloc</i> argument to the <i>cleartool mkview</i> command.</li>
+ <li><b>Use explicit path</b>. This entry generates a <i>-vws</i> argument to the <i>cleartool mkview</i> command.</li>
+</ul>
+<p></p></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DefaultViewStorage'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ServerViewStorage'</code><div>
+<ul><li><code>assignedLabelString : String</code>
+<div><p>Label expression used to populate view storage location dropdown.</p></div>
+
+</li>
+<li><code>server : String</code>
+<div><p>The view storage location that will be passed to the <i>-stgloc</i> option.<br> The list of available servers is retrieved using <i>cleartool lsstgloc -view</i><br> Note that auto is always available.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SpecificViewStorage'</code><div>
+<ul><li><code>winStorageDir : String</code>
+</li>
+<li><code>unixStorageDir : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>buildFoundationBaseline : boolean</code>
+<div><p>If checked, instead of creating a view on the current stream, the job will look up the current foundation baselines for the given stream and work in readonly on these baselines. If polling is enabled, the build will be triggered every time a new foundation baseline is detected on the given stream.</p></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneWorkspaceSCM'</code><div>
+<ul><li><code>parentJobName : String</code>
+</li>
+<li><code>criteria : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'CmvcSCM'</code><div>
+<ul><li><code>family : String</code>
+</li>
+<li><code>become : String</code>
+</li>
+<li><code>releases : String</code>
+</li>
+<li><code>checkoutScript : String</code>
+</li>
+<li><code>trackViewReportWhereClause : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ConfigurationRotator'</code><div>
+<ul><li><code>acrs</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'ClearCaseUCM'</code><div>
+<ul><li><code>pvobName : String</code>
+</li>
+<li><code>contribute : boolean</code>
+<div><div>
+ <p>Contribute data to a global database. Defined in the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Compatibility+Action+Storage+Plugin" rel="nofollow">Compatibility Action Storage Plugin</a>.</p>
+</div></div>
+
+</li>
+<li><code>targets</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>baselineName : String</code>
+</li>
+<li><code>level</code>
+<ul><li><b>Values:</b> <code>INITIAL</code>, <code>BUILT</code>, <code>TESTED</code>, <code>RELEASED</code>, <code>REJECTED</code></li></ul></li>
+<li><code>fixed : boolean</code>
+</li>
+</ul></li>
+<li><code>useNewest : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'Git'</code><div>
+<ul><li><code>targets</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+</li>
+<li><code>repository : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+<li><code>commitId : String</code>
+</li>
+<li><code>fixed : boolean</code>
+</li>
+</ul></li>
+<li><code>useNewest : boolean</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CvsProjectset'</code><div>
+<ul><li><code>repositories</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>cvsRoot : String</code>
+<div><div>
+ The CVS connection string Jenkins uses to connect to the server. The format is the same as $CVSROOT environment variable (:protocol:user@host:path)
+</div></div>
+
+</li>
+<li><code>passwordRequired : boolean</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryItems</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>location</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'BranchRepositoryLocation'</code><div>
+<ul><li><code>branchName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'HeadRepositoryLocation'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TagRepositoryLocation'</code><div>
+<ul><li><code>tagName : String</code>
+</li>
+<li><code>useHeadIfNotFound : boolean</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>modules</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remoteName : String</code>
+<div><div>
+ The name of the module in the repository at CVSROOT
+</div></div>
+
+</li>
+<li><code>localName : String</code>
+<div><div>
+ The name to be applied to this module in the local workspace. If this is left blank then the remote module name will be used. This is similar to the 'checkout-as' function available on many CVS clients.
+</div></div>
+
+</li>
+<li><code>projectsetFileName : String</code>
+<div><div>
+ The name of the file in this module to parse for projectset entries.
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+<li><code>excludedRegions</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p>Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 src/main/web/.*\.html
+	 src/main/web/.*\.jpeg
+	 src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p>More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pattern : String</code>
+</li>
+</ul></li>
+<li><code>compressionLevel : int</code>
+</li>
+<li><code>repositoryBrowser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+</ul></li>
+<li><code>canUseUpdate : boolean</code>
+<div><div>
+ If checked, Jenkins will use 'cvs update' whenever possible for builds. This makes a build faster. But this also causes the artifacts from the previous build to remain in the file system when a new build starts, making it not a true clean build.
+</div></div>
+
+</li>
+<li><code>username : String</code>
+<div><div>
+ This username will be used for the checkout of any modules parsed from the projectset file if no match was found against the parsed CVSROOT using the globally configured authentication.
+</div></div>
+
+</li>
+<li><code>password : String</code>
+<div><div>
+ This password will be used for the checkout of any modules parsed from the projectset file if no match was found against the parsed CVSROOT using the globally configured authentication.
+</div></div>
+
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEyeCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of FishEye for this repository (such as <a href="http://deadlock.netbeans.org/fisheye/browse/netbeans/" rel="nofollow">this</a>.)
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'OpenGrok'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of OpenGrok for this repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewCVS'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewCVS for this repository (such as <a href="http://relaxngcc.cvs.sourceforge.net/relaxngcc/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>skipChangeLog : boolean</code>
+<div><div>
+ Prevent the changelog being generated after checkout has completed. This will stop any changes being shown on the changes screen but reduces load on your CVS server.
+</div></div>
+
+</li>
+<li><code>pruneEmptyDirectories : boolean</code>
+<div><div>
+ Remove empty directories after checkout using the CVS '-P' option.
+</div></div>
+
+</li>
+<li><code>disableCvsQuiet : boolean</code>
+<div><div>
+ Instructs CVS to show all logging output. CVS normally runs in quiet mode but this option disables that.
+</div></div>
+
+</li>
+<li><code>cleanOnFailedUpdate : boolean</code>
+<div><div>
+ If the job is configured to use CVS update and the update step fails for any reason then the workspace will be wiped-out and a clean checkout done instead.
+</div></div>
+
+</li>
+<li><code>forceCleanCopy : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DarcsScm'</code><div>
+<ul><li><code>source : String</code>
+</li>
+<li><code>localDir : String</code>
+</li>
+<li><code>clean : boolean</code>
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'DarcsWeb'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'Darcsden'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'DimensionsSCM'</code><div>
+<ul><li><code>project : String</code>
+</li>
+<li><code>credentialsType : String</code>
+</li>
+<li><code>userName : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>pluginServer : String</code>
+</li>
+<li><code>userServer : String</code>
+</li>
+<li><code>keystoreServer : String</code>
+</li>
+<li><code>pluginDatabase : String</code>
+</li>
+<li><code>userDatabase : String</code>
+</li>
+<li><code>keystoreDatabase : String</code>
+</li>
+<li><code>keystorePath : String</code>
+</li>
+<li><code>certificateAlias : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>certificatePassword : String</code>
+</li>
+<li><code>keystorePassword : String</code>
+</li>
+<li><code>certificatePath : String</code>
+</li>
+<li><code>remoteCertificatePassword : String</code>
+</li>
+<li><code>secureAgentAuth : boolean</code>
+</li>
+<li><code>canJobDelete : boolean</code> (optional)
+</li>
+<li><code>canJobExpand : boolean</code> (optional)
+</li>
+<li><code>canJobForce : boolean</code> (optional)
+</li>
+<li><code>canJobNoMetadata : boolean</code> (optional)
+</li>
+<li><code>canJobNoTouch : boolean</code> (optional)
+</li>
+<li><code>canJobRevert : boolean</code> (optional)
+</li>
+<li><code>canJobUpdate : boolean</code> (optional)
+</li>
+<li><code>eol : String</code> (optional)
+</li>
+<li><code>folders</code> (optional)
+<ul><b>Array / List of Nested Object</b>
+<li><code>value : String</code>
+</li>
+</ul></li>
+<li><code>pathsToExclude</code> (optional)
+<ul><b>Array / List of Nested Object</b>
+<li><code>value : String</code>
+</li>
+</ul></li>
+<li><code>permissions : String</code> (optional)
+</li>
+<li><code>timeZone : String</code> (optional)
+</li>
+<li><code>webUrl : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'DrushMakefileSCM'</code><div>
+<ul><li><code>makefile : String</code>
+<div><div>
+ <p>Specify the content of the <a href="https://www.drupal.org/node/1432374" rel="nofollow">Makefile</a>. Support for YAML Makefiles depends on the version of Drush you have installed.</p>
+ <p>This example will generate a vanilla Drupal 7.38:</p>
+ <pre>    api=2
+    core=7.x
+    projects[drupal][version]=7.38
+    </pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>root : String</code>
+<div><div>
+ Specify a local directory for the Drupal root (relative to the <a rel="nofollow">workspace root</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'EndevorConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>filterPattern : String</code>
+</li>
+<li><code>fileExtension : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+</ul></div></li>
+<li><code>filesystem</code><div>
+<ul><li><code>path : String</code>
+<div><div>
+ <p>The file path for the source code.</p>
+ <p>e.g. \\Server1\project1\src or c:\myproject\src</p>
+ <p>Note for distributed build environment, please make sure the path is accessible on remote node(s)</p>
+</div></div>
+
+</li>
+<li><code>clearWorkspace : boolean</code>
+<div><div>
+ <p>If true, the system will delete all existing files/sub-folders in workspace before checking-out. Poll changes will not be affected by this setting.</p>
+</div></div>
+
+</li>
+<li><code>copyHidden : boolean</code>
+<div><div>
+ <p>If true, the system will copy hidden files and folders as well. Default is false.</p>
+</div></div>
+
+</li>
+<li><code>filterSettings</code>
+<ul><b>Nested Object</b>
+<li><code>includeFilter : boolean</code>
+</li>
+<li><code>selectors</code>
+<div><div>
+ <p>You can apply wildcard filter(s) when detecting changes and copying files. By default, the system will filter out hidden files, on Unix, that means files/folder starting with ".", on Windows, that means files/folders with "hidden" attribute. You may want to filter out, e.g. files with ".tmp" extension.</p>
+ <p>Note: filters are applied on both sides, source and destination (i.e. the workspace). E.g. if you filter out ".tmp" files, all ".tmp" files currently in workspace will not be removed.</p>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>wildcard : String</code>
+<div><div>
+ <p>ANT style wildcard.</p>
+ <p>To include just *.java, set filter type to "Include" and type add "*.java" (without quote) in the wildcard. To exclude *.exe" and all JUnit test cases, set filter type to "Exclude" and add two wildcard, one for "*.dll" and one for "*Test*"</p>
+ <p>To exclude a directory, set filter to "**/dir_to_exclude/**"</p>
+ <p>Note: (1) the wildcard is case insensitive, (2) all backslashes (\) will be replaced with slashes (/)</p>
+</div></div>
+
+</li>
+</ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'FeatureBranchAwareMercurialSCM'</code><div>
+<ul><li><code>installation : String</code>
+</li>
+<li><code>source : String</code>
+<div><div>
+ Specify the repository to track. This can be URL or a local file path.
+</div></div>
+
+</li>
+<li><code>branch : String</code>
+<div><div>
+ Specify the branch name if you'd like to track a specific branch in a repository. Leave this field empty otherwise, to track the "default" branch.
+</div></div>
+
+</li>
+<li><code>modules : String</code>
+<div><div>
+ Reduce unnecessary builds by specifying a comma or space delimited list of "modules" within the repository. A module is a directory name within the repository that this project lives in. If this field is set, changes outside the specified modules will not trigger a build (even though the whole repository is checked out anyway due to the Mercurial limitation.)
+</div></div>
+
+</li>
+<li><code>subdir : String</code>
+<div><div>
+ If not empty, check out the Mercurial repository into this subdirectory of the job's workspace. For example: <code>my/sources</code> (use forward slashes). If changing this entry, you probably want to clean the workspace first.
+</div></div>
+
+</li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEye'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository, such as: http://www.example.org/browse/hg/
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GoogleCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="http://code.google.com/p/PROJECTNAME/source/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'HgWeb'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://www.mercurial-scm.org/repo/hg/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Kallithea'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnHG'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://acme.kilnhg.com/Repo/Repositories/Group/PROJECTNAME" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCodeLegacy'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManager'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <code>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</code>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>clean : boolean</code>
+<div><div>
+ When this option is checked, each build will wipe any local modifications or untracked files in the repository checkout. This is often a convenient way to ensure that a build is not using any artifacts from earlier builds.
+</div></div>
+
+</li>
+<li><code>branchPattern : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'GeneXusServerSCM'</code><div>
+<div><div>
+ Checks out (or updates) a Knowledge Base from a GeneXus&nbsp;Server.
+</div></div>
+<ul><li><code>gxInstallationId : String</code>
+<div><div>
+ <p>GeneXus installation to use when creating (or updating) a local copy of a Knowledge&nbsp;Base from a GeneXus&nbsp;Server.</p>
+ <p>Select "(Custom)" if you want to specify a custom GeneXus path for this project (see Advanced Options).</p>
+ <p>The options that appear here are those you may configure in Jenkins "Global Tool Configuration" for GeneXus.</p>
+</div></div>
+
+</li>
+<li><code>gxCustomPath : String</code>
+<div><div>
+ <p>Custom path to a GeneXus installation to use when creating (or updating) a local copy of Knowledge&nbsp;Base from a GeneXus&nbsp;Server. This custom path is used when the "Custom" option is selected for the GeneXus&nbsp;Installation</p>
+</div></div>
+
+</li>
+<li><code>msbuildCustomPath : String</code>
+<div><div>
+ <p>Custom path to the MSBuild installation to use when creating (or updating) a local copy of Knowledge&nbsp;Base from a GeneXus&nbsp;Server.</p>
+</div></div>
+
+</li>
+<li><code>serverURL : String</code>
+<div><div>
+ URL of the GeneXus&nbsp;Server from which to obtain (or update) a local copy of a Knowledge&nbsp;Base (eg:&nbsp;"https://sandbox.genexusserver.com/v16").
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>Credentials to use when authenticating to the GeneXus&nbsp;Server.</p>
+ <p>Select the credentials you want to use or click "Add" to enter a new user/password pair.</p>
+</div></div>
+
+</li>
+<li><code>kbName : String</code>
+<div><div>
+ Name of the Knowledge&nbsp;Base in GeneXus&nbsp;Server from which to obtain (or update) a local copy.
+</div></div>
+
+</li>
+<li><code>kbVersion : String</code>
+<div><div>
+ <p>Name of the Version that will be selected when creating a local copy of the Knowledge Base.</p>
+ <p>If you leave it blank the 'Trunk' version will be selected by default.</p>
+</div></div>
+
+</li>
+<li><code>localKbPath : String</code>
+<div><div>
+ <p>Path to the local Knowledge Base to use as working copy.</p>
+ <p>If you leave it blank the default <code>${WORKSPACE}\KBname</code> will apply.</p>
+</div></div>
+
+</li>
+<li><code>localKbVersion : String</code>
+<div><div>
+ <p>Name of the Version in the local Knowledge Base that is linked to the Version in the server.</p>
+ <p>If you leave it blank the 'Trunk' version will be selected by default.</p>
+</div></div>
+
+</li>
+<li><code>kbDbServerInstance : String</code>
+<div><div>
+ SQL Server used by GeneXus for the local Knowledge Base.
+</div></div>
+
+</li>
+<li><code>kbDbCredentialsId : String</code>
+<div><div>
+ <p>Credentials to use when to connecting to SQL&nbsp;Server.</p>
+ <p>Select "none" for Windows Authentication.</p>
+</div></div>
+
+</li>
+<li><code>kbDbName : String</code>
+<div><div>
+ <p>Name of the SQL Server database used for the local Knowledge&nbsp;Base.</p>
+ <p>Leave it blank to use the default database name.</p>
+</div></div>
+
+</li>
+<li><code>kbDbInSameFolder : boolean</code>
+<div><div>
+ <p>Create the database files in the same folder as the Knowledge&nbsp;Base when checking out. Default is '<code>true</code>'.</p>
+ <p>If <code>kbDbInSameFolder</code> is true or not set, then the database files will be created in the same folder as the Knowledge&nbsp;Base. If <code>kbDbInSameFolder</code> is false, then the database files will be created in the default folder configured for the SQL Server at <code>kbDbServerInstance (optional)</code>.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCM'</code><div>
+<div><div>
+ <p>The <a href="https://plugins.jenkins.io/git/" rel="nofollow">git plugin</a> provides fundamental git operations for Jenkins projects. It can poll, fetch, checkout, and merge contents of git repositories.</p>
+ <p>The git plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step" rel="nofollow"><code>checkout</code></a> step. The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator" rel="nofollow"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.</p>
+</div></div>
+<ul><li><code>userRemoteConfigs</code>
+<div><div>
+ Specify the repository to track. This can be a URL or a local file path. Note that for super-projects (repositories with submodules), only a local file path or a complete URL is valid. The following are examples of valid git URLs. 
+ <ul>
+  <li>ssh://git@github.com/github/git.git</li>
+  <li>git@github.com:github/git.git (short notation for ssh protocol)</li>
+  <li>ssh://user@other.host.com/~/repos/R.git (to access the repos/R.git repository in the user's home directory)</li>
+  <li>https://github.com/github/git.git</li>
+ </ul> <br> If the repository is a super-project, the location from which to clone submodules is dependent on whether the repository is bare or non-bare (i.e. has a working directory). 
+ <ul>
+  <li>If the super-project is bare, the location of the submodules will be taken from <em>.gitmodules</em>.</li>
+  <li>If the super-project is <strong>not</strong> bare, it is assumed that the repository has each of its submodules cloned and checked out appropriately. Thus, the submodules will be taken directly from a path like <code>${SUPER_PROJECT_URL}/${SUBMODULE}</code>, rather than relying on information from <em>.gitmodules</em>.</li>
+ </ul> For a local URL/path to a super-project, <em>git rev-parse --is-bare-repository</em> is used to detect whether the super-project is bare or not. <br> For a remote URL to a super-project, the ending of the URL determines whether a bare or non-bare repository is assumed: 
+ <ul>
+  <li>If the remote URL ends with <em>/.git</em>, a <em>non</em>-bare repository is assumed.</li>
+  <li>If the remote URL does <strong>NOT</strong> end with <em>/.git</em>, a bare repository is assumed.</li>
+ </ul>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>url : String</code>
+<div><div>
+ Specify the URL or path of the git repository. This uses the same syntax as your <code>git clone</code> command.
+</div></div>
+
+</li>
+<li><code>name : String</code>
+<div><div>
+ ID of the repository, such as <code>origin</code>, to uniquely identify this repository among other remote repositories. This is the same "name" that you use in your <code>git remote</code> command. If left empty, Jenkins will generate unique names for you. 
+ <p>You normally want to specify this when you have multiple remote repositories.</p>
+</div></div>
+
+</li>
+<li><code>refspec : String</code>
+<div><div>
+ A refspec controls the remote refs to be retrieved and how they map to local refs. If left blank, it will default to the normal behaviour of <code>git fetch</code>, which retrieves all the branch heads as <code>remotes/REPOSITORYNAME/BRANCHNAME</code>. This default behaviour is OK for most cases. 
+ <p>In other words, the default refspec is "+refs/heads/*:refs/remotes/REPOSITORYNAME/*" where <code>REPOSITORYNAME</code> is the value you specify in the above "name of repository" textbox.</p>
+ <p>When do you want to modify this value? A good example is when you want to just retrieve one branch. For example, <code>+refs/heads/master:refs/remotes/origin/master</code> would only retrieve the master branch and nothing else.</p>
+ <p>The plugin uses a default refspec for its initial fetch, unless the "Advanced Clone Option" is set to honor refspec. This keeps compatibility with previous behavior, and allows the job definition to decide if the refspec should be honored on initial clone.</p>
+ <p>Multiple refspecs can be entered by separating them with a space character. <code>+refs/heads/master:refs/remotes/origin/master&nbsp;+refs/heads/develop:refs/remotes/origin/develop</code> retrieves the master branch and the develop branch and nothing else.</p>
+ <p>See <a href="https://git-scm.com/book/en/v2/Git-Internals-The-Refspec" rel="nofollow">the refspec definition in Git user manual</a> for more details.</p>
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ Credential used to <strong>check out</strong> sources.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>branches</code>
+<div><div>
+ List of branches to build. Jenkins jobs are most effective when each job builds only a single branch. When a single job builds multiple branches, the changelog comparisons between branches often show no changes or incorrect changes.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>name : String</code>
+<div><div>
+ <p>Specify the branches if you'd like to track a specific branch in a repository. If left blank, all branches will be examined for changes and built.</p>
+ <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch is unambiguous.</p>
+ <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented with a full path the plugin will only use the part of the string right of the last slash. Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+ <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>), you'll need to specify the origin repository in the branch names to make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+ <p>Possible options:</p>
+ <ul>
+  <li><strong><code>&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>master</code>, <code>feature1</code>, ...</li>
+  <li><strong><code>refs/heads/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...</li>
+  <li><strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily the expected one.<br> Better use <code>refs/heads/&lt;branchName&gt;</code>.<br> E.g. <code>origin/master</code></li>
+  <li><strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>remotes/origin/master</code></li>
+  <li><strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br> Tracks/checks out the specified branch.<br> E.g. <code>refs/remotes/origin/master</code></li>
+  <li><strong><code>&lt;tagName&gt;</code></strong><br> This does not work since the tag will not be recognized as tag.<br> Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br> E.g. <code>git-2.3.0</code></li>
+  <li><strong><code>refs/tags/&lt;tagName&gt;</code></strong><br> Tracks/checks out the specified tag.<br> E.g. <code>refs/tags/git-2.3.0</code></li>
+  <li><strong><code>&lt;commitId&gt;</code></strong><br> Checks out the specified commit.<br> E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...</li>
+  <li><strong><code>${ENV_VARIABLE}</code></strong><br> It is also possible to use environment variables. In this case the variables are evaluated and the result is used as described above.<br> E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...</li>
+  <li><strong><code>&lt;Wildcards&gt;</code></strong><br> The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>. In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.</li>
+  <li><strong><code>:&lt;regular expression&gt;</code></strong><br> The syntax is of the form: <code>:regexp</code>. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.<br> Examples:<br>
+   <ul>
+    <li><code>:^(?!(origin/prefix)).*</code>
+     <ul>
+      <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+      <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+     </ul></li>
+    <li><code>:origin/release-\d{8}</code>
+     <ul>
+      <li>matches: <code>origin/release-20150101</code></li>
+      <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+     </ul></li>
+    <li><code>:^(?!origin/master$|origin/develop$).*</code>
+     <ul>
+      <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+      <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+     </ul></li>
+   </ul></li>
+ </ul>
+ <p></p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>browser</code>
+<div><div>
+ Defines the repository browser that displays changes detected by the git plugin.
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AssemblaWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://www.assembla.com/code/PROJECT/git/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BacklogGitRepositoryBrowser'</code><div>
+<ul><li><code>repoName : String</code>
+</li>
+<li><code>repoUrl : String</code>
+</li>
+</ul></div></li>
+<li><code>bitbucketServer</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the Bitbucket Server root URL for this repository (such as <em>https://bitbucket:7990/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'BitbucketWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://bitbucket.org/OWNER/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://cgit.example.com:port/group/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'FisheyeGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the URL of this repository in FishEye (such as <em>http://fisheye6.cenqua.com/browse/ant/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBlitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository.
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in GitBlit.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitBucketBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLab'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlabserver:port/group/REPO/</em>).
+</div></div>
+
+</li>
+<li><code>version : String</code> (optional)
+<div><div>
+ Specify the major and minor version of GitLab you use (such as 9.1). If you don't specify a version, a modern version of GitLab (&gt;= 8.0) is assumed.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitLabBrowser'</code><div>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page so that links to changes can be automatically generated by Jenkins. The URL needs to include the owner and project. If the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>.
+</div></div>
+<ul><li><code>projectUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this project's GitLab page. The URL needs to include the owner and project so, for example, if the GitLab server is <code>https://gitLab.example.com</code> then the URL for bob's skunkworks project might be <code>https://gitLab.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitList'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gitlistserver:port/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://github.com/jenkinsci/jenkins.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GiteaBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Gitea page. The URL needs to include the owner and repository so, for example, if the Gitea server is <code>https://gitea.example.com</code> then the URL for bob's skunkworks project repository might be <code>https://gitea.example.com/bob/skunkworks</code>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GithubWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's GitHub page (such as <em>https://github.com/jquery/jquery</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Gitiles'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gwt.googlesource.com/gwt/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitoriousWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://gitorious.org/gitorious/mainline</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GogsGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://gogs.example.com:port/username/some-repo-url.git</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnGit'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://khanacademy.kilnhg.com/Code/Website/Group/webapp</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Phabricator'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the phabricator instance root URL (such as <em>http://phabricator.example.com</em>).
+</div></div>
+
+</li>
+<li><code>repo : String</code>
+<div><div>
+ Specify the repository name in phabricator (such as the <em>foo</em> part of <em>phabricator.example.com/diffusion/foo/browse</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RedmineWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://SERVER/PATH/projects/PROJECT/repository</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's RhodeCode page (such as <em>http://rhodecode.mydomain.com:5000/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManagerGitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://scm-manager.org/scm/repo/namespace/name</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Stash'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the HTTP URL for this repository's Stash page (such as <em>http://stash.mydomain.com:7990/projects/PROJECT/repos/REPO/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TFS2013GitRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Either the name of the remote whose URL should be used, or the URL of this module in TFS (such as <em>http://fisheye6.cenqua.com/tfs/PROJECT/_git/REPO/</em>). If empty (default), the URL of the "origin" repository is used. 
+ <p>If TFS is also used as the repository server, this can usually be left blank.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TracGitRepositoryBrowser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'TuleapBrowser'</code><div>
+<div><div>
+ Specify the HTTPS URL for the Tuleap Git repository so that links to changes can be automatically generated by Jenkins.
+</div></div>
+<ul><li><code>repositoryUrl : String</code>
+<div><div>
+ The URL is the web URL of the Tuleap Git repository.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewGitWeb'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+<li><code>projectName : String</code>
+<div><div>
+ Specify the name of the project in ViewGit (e.g. scripts, scuttle etc. from <em>http://code.fealdia.org/viewgit/</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>gitTool : String</code>
+<div><p>Absolute path to the git executable.</p>
+<p>This is <strong>different</strong> from other Jenkins tool definitions. Rather than providing the directory that contains the executable, you <strong>must provide the complete path to the executable</strong>. Setting '<code>/usr/bin/git</code>' would be correct, while setting '<code>/usr/bin/</code>' is not correct.</p></div>
+
+</li>
+<li><code>extensions</code>
+<div><div>
+ <p>Extensions add new behavior or modify existing plugin behavior for different uses. Extensions help users more precisely tune plugin behavior to meet their needs.</p>
+ <p>Extensions include:</p>
+ <ul>
+  <li><strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace. The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.</li>
+  <li><strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent. The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.</li>
+  <li><strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.</li>
+  <li><strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.</li>
+  <li><strong>Build initiation extensions</strong> control the conditions that start a build. They can ignore notifications of a change or force a deeper evaluation of the commits when polling.</li>
+  <li><strong>Merge extensions</strong> can optionally merge changes from other branches into the current branch of the agent workspace. They control the source branch for the merge and the options applied to the merge.</li>
+ </ul>
+ <p></p>
+</div></div>
+
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>$class: 'AuthorInChangelog'</code><div>
+<div><div>
+ The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets. If this option is selected, the Git commit's "Author" value would be used instead.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'BuildChooserSetting'</code><div>
+<div><div>
+ When you are interested in using a job to build multiple heads (most typically multiple branches), you can choose how Jenkins choose what branches to build in what order. 
+ <p>This extension point in Jenkins is used by many other plugins to control the job to build specific commits. When you activate those plugins, you may see them installing a custom strategy here.</p>
+</div></div>
+<ul><li><code>buildChooser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'AlternativeBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'AncestryBuildChooser'</code><div>
+<ul><li><code>maximumAgeInDays : int</code>
+</li>
+<li><code>ancestorCommitSha1 : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DefaultBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'DeflakeGitBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GerritTriggerBuildChooser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'InverseBuildChooser'</code><div>
+<ul></ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'BuildSingleRevisionOnly'</code><div>
+<div><div>
+ Disable scheduling for multiple candidate revisions.<br> If we have 3 branches:<br> ----A--.---.--- B<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br> jenkins would try to build (B) and (C).<br> This behaviour disables this and only builds one of them.<br> It is helpful to reduce the load of the Jenkins infrastructure when the SCM system like Bitbucket or GitHub should decide what commits to build.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ChangelogToBranch'</code><div>
+<div><div>
+ This method calculates the changelog against the specified branch.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>compareRemote : String</code>
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below.
+</div></div>
+
+</li>
+<li><code>compareTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to compare against.
+</div></div>
+
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'CheckoutOption'</code><div>
+<ul><li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for checkout.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanBeforeCheckout'</code><div>
+<div><div>
+ Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CleanCheckout'</code><div>
+<div><div>
+ Clean up the workspace after every checkout by deleting all untracked files and directories, including those which are specified in <code>.gitignore</code>. It also resets all <em>tracked</em> files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.
+</div></div>
+<ul><li><code>deleteUntrackedNestedRepositories : boolean</code> (optional)
+<div><div>
+ Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CloneOption'</code><div>
+<ul><li><code>shallow : boolean</code>
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code>
+<div><div>
+ Deselect this to perform a clone without tags, saving time and disk space when you just want to access what is specified by the refspec.
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for clone and fetch operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>honorRefspec : boolean</code> (optional)
+<div><div>
+ Perform initial clone using the refspec defined for the repository. This can save time, data transfer and disk space when you only need to access the references specified by the refspec.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CodeCommitURLHelper'</code><div>
+<ul><li><code>credentialId : String</code>
+<div><div>
+ <p>OPTIONAL: Select the credentials to use.<br> If not specified, defaults to the <a href="http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain" rel="nofollow"> DefaultAWSCredentialsProviderChain </a> behaviour - <b>*FROM THE JENKINS INSTANCE*</b></p>
+ <p>In the latter case, usage of IAM Role Profiles seems not to work, thus relying on environment variables / system properties or the ~/.aws/credentials file, thus not recommended.</p>
+</div></div>
+
+</li>
+<li><code>repositoryName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'DisableRemotePoll'</code><div>
+<div><div>
+ Git plugin uses git ls-remote polling mechanism by default when configured with a single branch (no wildcards!). This compare the latest built commit SHA with the remote branch without cloning a local copy of the repo.<br><br> If you don't want to / can't use this.<br><br> If this option is selected, polling will require a workspace and might trigger unwanted builds (see <a href="https://issues.jenkins.io/browse/JENKINS-10131" rel="nofollow">JENKINS-10131</a>).
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromChangeSet'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ExcludeFromPoll'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'GitLFSPull'</code><div>
+<div><div>
+ Enable <a href="https://git-lfs.github.com/" rel="nofollow">git large file support</a> for the workspace by pulling large files after the checkout completes. Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'GitSCMChecksExtension'</code><div>
+<ul><li><code>verboseConsoleLog : boolean</code> (optional)
+<div><div>
+ If this option is checked, verbose log will be output to build console; the verbose log is useful for debugging the publisher creation.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GitSCMStatusChecksExtension'</code><div>
+<ul><li><code>name : String</code> (optional)
+</li>
+<li><code>skip : boolean</code> (optional)
+</li>
+<li><code>skipProgressUpdates : boolean</code> (optional)
+</li>
+<li><code>suppressLogs : boolean</code> (optional)
+</li>
+<li><code>unstableBuildNeutral : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'GitTagMessageExtension'</code><div>
+<div><div>
+ If the revision checked out has a git tag associated with it, the tag name will be exported during the build as <strong>GIT_TAG_NAME</strong>. <br> If a message was specified when creating the tag, then that message will be exported during the build as the <strong>GIT_TAG_MESSAGE</strong> environment variable. <br> If no tag message was specified, the commit message will be used. <br> If you ticked the <strong>Use most recent tag</strong> option, and the revision checked out has no git tag associated with it, the parent commits will be searched for a git tag, and the rules stated above will apply to the first parent commit with a git tag. 
+ <p></p> If the revision has more than one tag associated with it, only the most recent tag will be taken into account, <strong>unless</strong> the refspec contains "refs/tags/" — i.e. builds are only triggered when certain tag names or patterns are matched — in which case the exact tag name that triggered the build will be used, even if it's not the most recent tag for this commit. <br> For this reason, if you're not using a tag-specific refspec but you <em>are</em> using the "Create a tag for every build" behaviour, you should make sure that the build-tagging behaviour is configured to run <em>after</em> this "export git tag message" behaviour. 
+ <p></p> Tag and commit messages which span multiple lines are no problem, though only the first 10000 lines of a tag's message will be exported.
+</div></div>
+<ul><li><code>useMostRecentTag : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IgnoreNotifyCommit'</code><div>
+<div><div>
+ If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository matches or not.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'LocalBranch'</code><div>
+<div><div>
+ If given, checkout the revision to build as HEAD on this branch. 
+ <p>If selected, and its value is an empty string or "**", then the branch name is computed from the remote branch without the origin. In that case, a remote branch origin/master will be checked out to a local branch named master, and a remote branch origin/develop/new-feature will be checked out to a local branch named develop/newfeature.</p>
+ <p>Please note that this has not been tested with submodules.</p>
+</div></div>
+<ul><li><code>localBranch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MessageExclusion'</code><div>
+<ul><li><code>excludedMessage : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct message. 
+ <p></p>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">Pattern</a> <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()" rel="nofollow">matching</a>
+ <p></p>
+ <pre>.*\[maven-release-plugin\].*</pre> The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have been committed to the SCM a build will not occur. 
+ <p></p> You can create more complex patterns using embedded flag expressions. 
+ <pre>(?s).*FOO.*</pre> This example will search FOO message in all comment lines.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PathRestriction'</code><div>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
+</div></div>
+<ul><li><code>includedRegions : String</code>
+<div><div>
+ Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. An empty list implies that everything is included. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that a build will only occur, if html/jpeg/gif files have been committed to the SCM. Exclusions take precedence over inclusions, if there is an overlap between included and excluded regions.
+</div></div>
+
+</li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" rel="nofollow">java regular expression pattern matching</a>, and must be separated by a new line. 
+ <p></p>
+ <pre>    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PerBuildTag'</code><div>
+<div><div>
+ Create a tag in the workspace for every build to unambiguously mark the commit that was built. You can combine this with Git publisher to push the tags to the remote repository.
+</div></div>
+<ul></ul></div></li>
+<li><code>$class: 'PreBuildMerge'</code><div>
+<div><div>
+ These options allow you to perform a merge to a particular branch before building. For example, you could specify an integration branch to be built, and to merge to master. In this scenario, on every change of integration, Jenkins will perform a merge with the master branch, and try to perform a build if the merge is successful. It then may push the merge back to the remote repository if the Git Push post-build action is selected.
+</div></div>
+<ul><li><code>options</code>
+<ul><b>Nested Object</b>
+<li><code>mergeTarget : String</code>
+<div><div>
+ The name of the branch within the named repository to merge to, such as <code>master</code>.
+</div></div>
+
+</li>
+<li><code>fastForwardMode</code> (optional)
+<div><div>
+ Merge fast-forward mode selection.<br> The default, --ff, gracefully falls back to a merge commit when required.<br> For more information, see the <a href="http://git-scm.com/docs/git-merge" rel="nofollow">Git Merge Documentation</a>
+</div></div>
+
+<ul><li><b>Values:</b> <code>FF</code>, <code>FF_ONLY</code>, <code>NO_FF</code></li></ul></li>
+<li><code>mergeRemote : String</code> (optional)
+<div><div>
+ Name of the repository, such as <code>origin</code>, that contains the branch you specify below. If left blank, it'll default to the name of the first repository configured above.
+</div></div>
+
+</li>
+<li><code>mergeStrategy</code> (optional)
+<div><div>
+ Merge strategy selection. <strong>This feature is not fully implemented in JGIT.</strong>
+</div></div>
+
+<ul><li><b>Values:</b> <code>DEFAULT</code>, <code>RESOLVE</code>, <code>RECURSIVE</code>, <code>OCTOPUS</code>, <code>OURS</code>, <code>SUBTREE</code>, <code>RECURSIVE_THEIRS</code></li></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>pretestedIntegration</code><div>
+<ul><li><code>gitIntegrationStrategy</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>accumulated</code><div>
+<div><h2>Accumulated Commit Strategy</h2>
+<div>
+ This strategy merges your commits with the --no-ff switch
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>ffonly</code><div>
+<div><h2>Fast Forward only (--ff-only) Strategy</h2>
+<div>
+ This strategy fast-forward only using the --ff-only switch - or fails
+</div></div>
+<ul><li><code>shortCommitMessage : boolean</code> (optional)
+</li>
+</ul></div></li>
+<li><code>squash</code><div>
+<div><h2>Squashed Commit Strategy</h2>
+<div>
+ This strategy squashes all your commit on a given branch with the --squash option
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>integrationBranch : String</code>
+<div><h3>What to specify</h3>
+<p>The branch name must match your integration branch name. <b>No trailing slash.</b></p>
+<h3>Merge is performed the following way</h3>
+<h5>Squash commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge --squash &lt;Branch matched by git&gt;
+            git commit -C &lt;Branch matched by git&gt;</pre>
+<h5>Accumulated commit</h5>
+<pre>            git checkout -B &lt;Branch name&gt; &lt;Repository name&gt;/&lt;Branch name&gt;
+            git merge -m &lt;commitMsg&gt; &lt;Branch matched by git&gt; --no-ff</pre>
+<h3>When changes are pushed to the integration branch?</h3>
+<p>Changes are only ever pushed when the build results is SUCCESS</p>
+<pre>            git push &lt;Repository name&gt; &lt;Branch name&gt;</pre></div>
+
+</li>
+<li><code>repoName : String</code>
+<div><div>
+ <h3>What to specify</h3>
+ <p>The repository name. In git the repository is always the name of the remote. So if you have specified a repository name in your Git configuration. You need to specify the exact same name here, otherwise no integration will be performed. We do the merge based on this.</p>
+ <p><b>No trailing slash on repository name.</b></p>
+ <p><span>Remember to specify this when working with NAMED repositories in Git</span></p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'PruneStaleBranch'</code><div>
+<div><div>
+ Run "git remote prune" for each remote, to prune obsolete local branches.
+</div></div>
+<ul></ul></div></li>
+<li><code>pruneTags</code><div>
+<ul><li><code>pruneTags : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RelativeTargetDirectory'</code><div>
+<ul><li><code>relativeTargetDir : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where the Git repository will be checked out. If left empty, the workspace root itself will be used. 
+ <p>This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted). Jenkins Pipeline already provides standard techniques for checkout to a subdirectory. Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" rel="nofollow">ws</a> and <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" rel="nofollow">dir</a> in Jenkins Pipeline rather than this extension.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmName'</code><div>
+<div><div>
+ <p>Unique name for this SCM. Needed when using Git within the Multi SCM plugin.</p>
+</div></div>
+<ul><li><code>name : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SparseCheckoutPaths'</code><div>
+<div><div>
+ <p>Specify the paths that you'd like to sparse checkout. This may be used for saving space (Think about a reference repository). Be sure to use a recent version of Git, at least above 1.7.10</p>
+</div></div>
+<ul><li><code>sparseCheckoutPaths</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>path : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'SubmoduleOption'</code><div>
+<ul><li><code>disableSubmodules : boolean</code>
+<div><div>
+ By disabling support for submodules you can still keep using basic git plugin functionality and just have Jenkins to ignore submodules completely as if they didn't exist.
+</div></div>
+
+</li>
+<li><code>recursiveSubmodules : boolean</code>
+<div><div>
+ Retrieve all submodules recursively (uses '--recursive' option which requires git&gt;=1.6.5)
+</div></div>
+
+</li>
+<li><code>trackingSubmodules : boolean</code>
+<div><div>
+ Retrieve the tip of the configured branch in .gitmodules (Uses '--remote' option which requires git&gt;=1.8.2)
+</div></div>
+
+</li>
+<li><code>reference : String</code>
+<div><div>
+ Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br> This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.<br> To prepare a reference folder with multiple subprojects, create a bare git repository and add all the remote urls then perform a fetch:<br>
+ <pre>  git init --bare
+  git remote add SubProject1 https://gitrepo.com/subproject1
+  git remote add SubProject2 https://gitrepo.com/subproject2
+  git fetch --all
+  </pre>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ Specify a timeout (in minutes) for submodules operations.<br> This option overrides the default timeout of 10 minutes. <br> You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" rel="nofollow">JENKINS-11286</a>). Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" rel="nofollow">JENKINS-22547</a>).
+</div></div>
+
+</li>
+<li><code>parentCredentials : boolean</code>
+<div><div>
+ Use credentials from the default remote of the parent project.
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ Set shallow clone depth, so that git will only download recent history of the project, saving time and disk space when you just want to access the latest commits of a repository.
+</div></div>
+
+</li>
+<li><code>shallow : boolean</code> (optional)
+<div><div>
+ Perform shallow clone, so that git will not download the history of the project, saving time and disk space when you just want to access the latest version of a repository.
+</div></div>
+
+</li>
+<li><code>threads : int</code> (optional)
+<div><div>
+ Specify the number of threads that will be used to update submodules.<br> If unspecified, the command line git default thread count is used.<br>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserExclusion'</code><div>
+<ul><li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p> Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well. 
+ <p></p>Each exclusion uses exact string comparison and must be separated by a new line. User names are only excluded if they exactly match one of the names in this list. 
+ <p></p>
+ <pre>auto_build_user</pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'UserIdentity'</code><div>
+<ul><li><code>name : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+<li><code>email : String</code>
+<div><div>
+ <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WipeWorkspace'</code><div>
+<div><div>
+ Delete the contents of the workspace before building, ensuring a fully fresh workspace.
+</div></div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>doGenerateSubmoduleConfigurations : boolean</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value and always uses <code>false</code> as its value.</p></div>
+
+</li>
+<li><code>submoduleCfg</code> (optional)
+<div><p>Removed facility that was intended to test combinations of git submodule versions. Removed in git plugin 4.6.0. Ignores the user provided value(s) and always uses empty values.</p></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>submoduleName : String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+</li>
+<li><code>branches : Array / List of String</code>
+<div><p><strong>Removed</strong> in git plugin 4.6.0.</p></div>
+
+<ul></ul></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'HarvestSCM'</code><div>
+<ul><li><code>broker : String</code>
+</li>
+<li><code>passwordFile : String</code>
+</li>
+<li><code>userId : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>projectName : String</code>
+</li>
+<li><code>state : String</code>
+</li>
+<li><code>viewPath : String</code>
+</li>
+<li><code>clientPath : String</code>
+</li>
+<li><code>processName : String</code>
+</li>
+<li><code>recursiveSearch : String</code>
+</li>
+<li><code>useSynchronize : boolean</code>
+</li>
+<li><code>extraOptions : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'IntegritySCM'</code><div>
+<div><div>
+ Checks out source code from "Windchill RV&amp;S for Configuration Management" repositories
+</div></div>
+<ul><li><code>serverConfig : String</code>
+</li>
+<li><code>configPath : String</code>
+</li>
+<li><code>configurationName : String</code>
+</li>
+<li><code>CPBasedMode : boolean</code> (optional)
+</li>
+<li><code>alternateWorkspace : String</code> (optional)
+</li>
+<li><code>browser</code> (optional)
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'IntegrityWebUI'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the PTC Windchill RV&amp;S Configuration Management server.<br> For example: http://hostname:7001<br> This value is optional and is used as an override to the URL detected in the Windchill RV&amp;S Change Log.
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>checkoutThreadPoolSize : int</code> (optional)
+</li>
+<li><code>checkoutThreadTimeout : int</code> (optional)
+</li>
+<li><code>checkpointBeforeBuild : boolean</code> (optional)
+</li>
+<li><code>checkpointLabel : String</code> (optional)
+</li>
+<li><code>cleanCopy : boolean</code> (optional)
+</li>
+<li><code>deleteNonMembers : boolean</code> (optional)
+</li>
+<li><code>excludeList : String</code> (optional)
+</li>
+<li><code>fetchChangedWorkspaceFiles : boolean</code> (optional)
+</li>
+<li><code>includeList : String</code> (optional)
+</li>
+<li><code>lineTerminator : String</code> (optional)
+</li>
+<li><code>localClient : boolean</code> (optional)
+</li>
+<li><code>password : String</code> (optional)
+</li>
+<li><code>restoreTimestamp : boolean</code> (optional)
+</li>
+<li><code>sandboxScope : String</code> (optional)
+</li>
+<li><code>skipAuthorInfo : boolean</code> (optional)
+</li>
+<li><code>userName : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'IspwConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>serverConfig : String</code>
+</li>
+<li><code>serverStream : String</code>
+</li>
+<li><code>serverApplication : String</code>
+</li>
+<li><code>serverLevel : String</code>
+</li>
+<li><code>levelOption : String</code>
+</li>
+<li><code>componentType : String</code>
+</li>
+<li><code>folderName : String</code>
+</li>
+<li><code>ispwDownloadAll : boolean</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+<li><code>ispwDownloadIncl : boolean</code>
+</li>
+<li><code>ispwDownloadWithCompileOnly : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'IspwContainerConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>serverConfig : String</code>
+</li>
+<li><code>containerName : String</code>
+</li>
+<li><code>containerType : String</code>
+</li>
+<li><code>serverLevel : String</code>
+</li>
+<li><code>componentType : String</code>
+</li>
+<li><code>ispwDownloadAll : boolean</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+<li><code>ispwDownloadIncl : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'MercurialSCM'</code><div>
+<ul><li><code>source : String</code>
+<div><div>
+ Specify the repository to track. This can be URL or a local file path. If you are specifying HTTP credentials, do <em>not</em> include a username in the URL.
+</div></div>
+
+</li>
+<li><code>browser</code> (optional)
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'FishEye'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository, such as: http://www.example.org/browse/hg/
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'GoogleCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="http://code.google.com/p/PROJECTNAME/source/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'HgWeb'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://www.mercurial-scm.org/repo/hg/" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Kallithea'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'KilnHG'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://acme.kilnhg.com/Repo/Repositories/Group/PROJECTNAME" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCode'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'RhodeCodeLegacy'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <a href="https://rhodecode.server/repo_name" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManager'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <code>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</code>).
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>clean : boolean</code> (optional)
+<div><div>
+ When this option is checked, each build will wipe any local modifications or untracked files in the repository checkout. This is often a convenient way to ensure that a build is not using any artifacts from earlier builds.
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code> (optional)
+<div><div>
+ Optional credentials to use when cloning or pulling from the remote repository. Supports username/password with HTTP(S) URLs, and SSH private key with SSH URLs.
+</div></div>
+
+</li>
+<li><code>disableChangeLog : boolean</code> (optional)
+<div><div>
+ When checked, Hudson will not calculate the Mercurial changelog for each build. Disabling the changelog can decrease the amount of time needed to update a very large repository.
+</div></div>
+
+</li>
+<li><code>installation : String</code> (optional)
+</li>
+<li><code>modules : String</code> (optional)
+<div><div>
+ Reduce unnecessary builds by specifying a comma or space delimited list of "modules" within the repository. A module is a directory name within the repository that this project lives in. If this field is set, changes outside the specified modules will not trigger a build (even though the whole repository is checked out anyway due to the Mercurial limitation.)
+</div></div>
+
+</li>
+<li><code>revision : String</code> (optional)
+<div><div>
+ Specify the branch or tag name you would like to track. (If you do not type anything, the default value is the <code>default</code> branch.)
+</div></div>
+
+</li>
+<li><code>revisionType</code> (optional)
+<div><div>
+ Specify the kind of revision you expect Jenkins to update your working copy to.
+</div></div>
+
+<ul><li><b>Values:</b> <code>BRANCH</code>, <code>TAG</code>, <code>CHANGESET</code>, <code>REVSET</code></li></ul></li>
+<li><code>subdir : String</code> (optional)
+<div><div>
+ If not empty, check out the Mercurial repository into this subdirectory of the job's workspace. For example: <code>my/sources</code> (use forward slashes). If changing this entry, you probably want to clean the workspace first.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'MergeBotUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'MultiSCM'</code><div>
+</div></li>
+<li><code>none</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'OpenShiftImageStreams'</code><div>
+<ul><li><code>imageStreamName : String</code>
+<div><div>
+ The name of the ImageStream is what shows up in the NAME column if you dump all the ImageStream's with the `oc get is` command invocation.
+</div></div>
+
+</li>
+<li><code>tag : String</code>
+<div><div>
+ The specific image tag within the ImageStream to monitor.
+</div></div>
+
+</li>
+<li><code>apiURL : String</code>
+</li>
+<li><code>namespace : String</code>
+</li>
+<li><code>authToken : String</code>
+</li>
+<li><code>verbose : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PdsConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>filterPattern : String</code>
+</li>
+<li><code>fileExtension : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+</ul></div></li>
+<li><code>perforce</code><div>
+<ul><li><code>credential : String</code>
+<div><div><b>Perforce Credentials</b>
+ <p>Select the appropriate credential for the Perforce connection. Perforce Credentials are defined in the Jenkins Credentials plugin <a rel="nofollow">here</a>.</p>
+ <p>There are two types:</p>
+ <ul>
+  <li>'Perforce Password Credential' for standard username/password authentication</li>
+  <li>'Perforce Ticket Credential' for ticket based authentication.</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>workspace</code>
+<div><div><b>Workspace Behaviour</b>
+ <p>Select the appropriate Perforce workspace behaviour from the list. Not all modes will suit all Jenkins Job build types.</p>
+ <p>There are five types:</p>
+ <ul>
+  <dt>
+   Manual
+  </dt>
+  <dd>
+   Manually define the Workspace view and sync options. Existing workspace will by updated or a new workspace created.
+  </dd>
+  <dt>
+   Spec File
+  </dt>
+  <dd>
+   Use a pre-defined Workspace Spec file versioned in Perforce.
+  </dd>
+  <dt>
+   Static
+  </dt>
+  <dd>
+   Use a pre-defined Workspace; must already exist and have a valid view.
+  </dd>
+  <dt>
+   Streams
+  </dt>
+  <dd>
+   Auto create/update a Streams workspace with a view determined by the chosen stream.
+  </dd>
+  <dt>
+   Template
+  </dt>
+  <dd>
+   Auto create/update a normal workspace with a view determined by the template workspace.
+  </dd>
+ </ul>
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>manualSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>Workspace name</b>
+ <p>Specify the name of the Perforce workspace to be used as the Jenkins build workspace. If the workspace does not yet exist, the configuration will be saved in Jenkins; the workspace is created only when it is to be used. If the workspace exists and you are connected to a Perforce server the auto-text fill should list suitable workspaces; updates are only applied when the workspace is used.</p>
+</div></div>
+
+</li>
+<li><code>spec</code>
+<ul><b>Nested Object</b>
+<li><code>allwrite : boolean</code>
+</li>
+<li><code>clobber : boolean</code>
+</li>
+<li><code>compress : boolean</code>
+</li>
+<li><code>locked : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>rmdir : boolean</code>
+</li>
+<li><code>streamName : String</code>
+</li>
+<li><code>line : String</code>
+<div><div><b>Line Endings</b>
+ <p>Set line-ending character(s) for client text files.</p>
+ <ul>
+  <li><b>UNIX</b> <p>linefeed: UNIX style.</p></li>
+  <li><b>MAC</b> <p>carriage return: Macintosh style. (obsolete)</p></li>
+  <li><b>WIN</b> <p>carriage return-linefeed: Windows style.</p></li>
+  <li><b>SHARE</b> <p>hybrid: writes UNIX style but reads UNIX, Mac or Windows style.</p></li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>view : String</code>
+<div><div><b>View</b>
+ <p>Lines to map depot files into the client workspace.</p>
+ <p>The variable ${P4_CLIENT} will expand to the client name, for example, a simple mapping:</p>
+ <p>//depot/... //${P4_CLIENT}/...</p>
+ <p>Maps files in the depot to files in your client workspace. Defines the files that you want in your client workspace and specifies where you want them to reside. The default view maps all depot files onto the client. See 'p4 help views' for view syntax. A new view takes effect on the next 'p4 sync'.</p>
+ <p>To support migration from the old Perforce plugin, a View Mapping can be inserted from a file in Perforce. Add the depot path to the "View Mappings" field Prefix "@" (this only applies to the "Manual" Workspace behaviour).</p>
+</div></div>
+
+</li>
+<li><code>changeView : String</code>
+</li>
+<li><code>type : String</code>
+<div><div><b>Type</b>
+ <p>Type of client: writeable/readonly/partitioned/graph</p>
+ <p>By default all clients are 'writeable', certain clients are short lived and perform long sync and build cycles. Over time these build clients can fragment the 'db.have' table which is used to track what files a client has synced. Setting a type of 'readonly' gives the client its own personal 'db.have' database table. A 'readonly' client cannot 'edit' or 'submit' files, however for build automation this is not usually a requirement and the performance tradeoff is worth considering if your build automation is causing issues with the 'db.have' table. This option requires that an administrator has first configured the 'client.readonly.dir' setting. If it is necessary to submit changes as part of your build, you may specify a 'partitioned' client: like a 'reaonly' client, this type also has a separate 'db.have' table under the 'client.readonly.dir' directory, but allows journalled 'edit' and 'submit' of files.</p>
+</div></div>
+
+</li>
+<li><code>serverID : String</code>
+</li>
+<li><code>backup : boolean</code>
+<div><div><b>Backup</b>
+ <p>Client's participation in backup enable/disable. If not specified backup of a writable client defaults to enabled.</p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>cleanup : boolean</code>
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>specFileSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>An existing workspace</b>
+ <p>Specify the name of the Perforce workspace to be used as the Jenkins build workspace. If the workspace does not yet exist, the configuration will be saved in Jenkins; the workspace is created only when it is to be used. If the workspace exists and you are connected to a Perforce server the auto-text fill should list suitable workspaces; updates are only applied when the workspace is used.</p>
+</div></div>
+
+</li>
+<li><code>specPath : String</code>
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>staticSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>An existing workspace</b>
+ <p>Specify the name of an existing workspace in Perforce to be used as the Jenkins build workspace. If connected to a Perforce server the auto-text fill should list suitable workspaces</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>streamSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>streamName : String</code>
+<div><div><b>Stream codeline</b>
+ <p>Specify the full Perforce depot path for the given stream. If connected to a Perforce server the auto-text fill should list possible streams.</p> <i>For example: //stream-depot/main-stream</i>
+</div></div>
+
+</li>
+<li><code>format : String</code>
+<div><div><b>Workspace name formatter</b>
+ <p>Jenklin slave nodes must each use a unique Perforce workspace. The format string configures the workspace name by substituting the specified variables: (at least one variable must be used)</p>
+ <p>Variables can be taken from the Jenkins <a rel="nofollow">Environment</a> or Parameterized builds</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>templateSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>templateName : String</code>
+<div><div><b>Templace workspace</b>
+ <p>Specify the name of an existing workspace in Perforce used to create or update a Jenkins build workspace. If connected to a Perforce server the auto-text fill should list suitable workspaces</p>
+</div></div>
+
+</li>
+<li><code>format : String</code>
+<div><div><b>Workspace name formatter</b>
+ <p>Jenklin slave nodes must each use a unique Perforce workspace. The format string configures the workspace name by substituting the specified variables: (at least one variable must be used)</p>
+ <p>Variables can be taken from the Jenkins <a rel="nofollow">Environment</a> or Parameterized builds</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>filter</code>
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>latest</code><div>
+<ul><li><code>latestChange : boolean</code>
+</li>
+</ul></div></li>
+<li><code>pathFilter</code><div>
+<ul><li><code>path : String</code>
+<div><div><b>Depot path filter</b>
+ <p>Changes can be filtered to not trigger a build; if all the files within a change match the specified path, the build is filtered.</p>
+ <p>For example, with a Filter of " <code>//depot/main/tests</code> ":</p>
+ <p><strong>Case A</strong> (change will be filtered):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/index.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+  <li><code>//depot/main/tests/002/test.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (change will not be filtered, as build.xml is outside of the filter):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+  <li><code>//depot/main/tests/004/test.xml</code></li>
+  <li><code>//depot/main/tests/005/test.xml</code></li>
+ </ul>
+ <p>This is not Perforce syntax. Use of ... and * patterns are not supported. Only paths to directories are supported.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>viewPattern</code><div>
+<ul><li><code>patternText : String</code>
+<div><div><b>Java Pattern filter</b>
+ <p>Changes can be filtered to not trigger a build; if none of the files within a change match a Java pattern (regular expression) listed, the build is filtered.</p>
+ <p>For example, with the following regular expressions: <br> <code>//depot/main/tests.*</code> <br> <code>//depot/main/src/.*\.cpp</code> <br> <code>//depot/main/build/.*(?:\.rb|\.py|\.bat|Jenkinsfile)</code> <br> <code>//depot/main/lib/(?!Lib1|Lib2).*</code> <br></p>
+ <p><strong>Case A</strong> (change will not be filtered, as these files match our first pattern on "tests"):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/CONTRIUBTING.md</code></li>
+  <li><code>//depot/main/tests/001/index.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (Be careful with incomplete file paths! Change will NOT be filtered, <br>as this file matches a pattern which was likely intended as describing a <strong>"tests/"</strong> directory.)</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests.doc</code></li>
+ </ul>
+ <p><strong>Case C</strong> (change will NOT be filtered, as all files match our fourth pattern looking for script files in 'build/'):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/build/rbs/deploy_server.rb</code></li>
+  <li><code>//depot/main/build/deploy/deploy.bat</code></li>
+  <li><code>//depot/main/build/Jenkinsfile</code></li>
+ </ul>
+ <p><strong>Case D</strong> (change will be filtered, as no file matches our second pattern for ".cpp" files under "main/src"):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/howto.doc</code></li>
+  <li><code>//depot/main/src/oldmain.c</code></li>
+  <li><code>//depot/main/src/art/splash.bmp</code></li>
+  <li><code>//depot/main/src/bt/funnelcake.php</code></li>
+ </ul>
+ <p><strong>Case E</strong> (change will be filtered. Lib1 is included in a negative lookahead, and thus is excluded.)</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/lib/Lib1/build.xml</code></li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>caseSensitive : boolean</code>
+</li>
+</ul></div></li>
+<li><code>incremental</code><div>
+<ul><li><code>perChange : boolean</code>
+<div><div><b>Polling per change</b>
+ <p>When enabled, only the one, oldest changelist returned by polling is built.</p>
+ <p>If <code>P4_INCREMENTAL</code> environment variable (or build parameter) is set to "false", polling per change is ignored and all changelists are built.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>userFilter</code><div>
+<ul><li><code>user : String</code>
+<div><div><b>User name filter</b>
+ <p>Changes can be filtered to not trigger a build; if the owner of a change matches the specified name, the build is filtered.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>viewFilter</code><div>
+<ul><li><code>viewMask : String</code>
+<div><div><b>View Mask filter</b>
+ <p>Changes can be filtered to not trigger a build; if none of the files within a change are contained in the view mask, the build is filtered.</p>
+ <p>For example, with a View Mask Filter of: <br> <code>//depot/main/tests</code> <br> <code>-//depot/main/tests/001</code> <br></p>
+ <p><strong>Case A</strong> (change will not be filtered, as index.xml is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/index.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (change will not be filtered, as index.xml is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/test/index.xml</code></li>
+  <li><code>//depot/main/src/build.xml</code></li>
+ </ul>
+ <p><strong>Case C</strong> (change will be filtered, as no file is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+ </ul>
+ <p><strong>Case D</strong> (change will be filtered, as no file is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+ </ul>
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>populate</code>
+<div><div><b>Populate Options</b>
+ <p>Perforce will populate the workspace with the file revisions needed for the build. The different options effect the way the workspace is cleaned and the file revisions are updated.</p>
+ <p>There are three options:</p>
+ <ul>
+  <dt>
+   Automatic Cleanup and Sync
+  </dt>
+  <dd>
+   Efficient cleaning and syncing of file revisions. Extra (non versioned files) are removed, missing and modified files re-added. <br>Best for clean builds.
+  </dd>
+  <dt>
+   Flush Workspace
+  </dt>
+  <dd>
+   No files Sync or cleanup attempted, but the Workspace's have list is updated. <br>Effective command 'p4 sync -k'.
+  </dd>
+  <dt>
+   Force Clean and Sync
+  </dt>
+  <dd>
+   Will remove all files from under the workspace root, then force sync the required files. Inefficient and NOT RECOMENDED.
+  </dd>
+  <dt>
+   Graph Force Clean and Sync/dt&gt;
+  </dt>
+  <dd>
+   For Graph and Hybrid only, will remove all files from under the workspace root, then force sync the required files.
+  </dd>
+  <dt>
+   Preview Check Only
+  </dt>
+  <dd>
+   No files Sync or cleanup attempted; the Workspace's have list is not updated. <br>Effective command 'p4 sync -n'.
+  </dd>
+  <dt>
+   Sync Only
+  </dt>
+  <dd>
+   No cleanup attempted; the sync will update all files (as CLOBBER is set) to the required set of revisions. <br>Best for incremental builds.
+  </dd>
+ </ul>
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>autoClean</code><div>
+<ul><li><code>replace : boolean</code>
+<div><div><b>REPLACE missing/modified files</b>
+ <p>Perforce will check out and overwrite any depot files which are either missing from workspace, or have been modified locally.</p>
+</div></div>
+
+</li>
+<li><code>delete : boolean</code>
+<div><div><b>DELETE generated files</b>
+ <p>Perforce will delete any local files that are not in the depot.</p>
+</div></div>
+
+</li>
+<li><code>tidy : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>previewOnly</code><div>
+<ul><li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+</li>
+</ul></div></li>
+<li><code>flushOnly</code><div>
+<ul><li><code>quiet : boolean</code>
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will flush only to the specified label or changelist number. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>forceClean</code><div>
+<ul><li><code>have : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>graphClean</code><div>
+<ul><li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>syncOnly</code><div>
+<ul><li><code>revert : boolean</code>
+</li>
+<li><code>have : boolean</code>
+</li>
+<li><code>force : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+</ul></li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>fishEye</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>rootModule : String</code>
+</li>
+</ul></div></li>
+<li><code>openGrok</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>depotPath : String</code>
+</li>
+<li><code>projectName : String</code>
+</li>
+</ul></div></li>
+<li><code>p4Web</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>swarm</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'PlasticSCM'</code><div>
+<ul><li><code>selector : String</code>
+</li>
+<li><code>cleanup</code>
+<ul><li><b>Values:</b> <code>MINIMAL</code>, <code>STANDARD</code>, <code>FULL</code>, <code>DELETE</code></li></ul></li>
+<li><code>workingMode</code>
+<ul><li><b>Values:</b> <code>NONE</code>, <code>UP</code>, <code>LDAP</code></li></ul></li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>useMultipleWorkspaces : boolean</code>
+</li>
+<li><code>additionalWorkspaces</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>selector : String</code>
+</li>
+<li><code>cleanup</code>
+<ul><li><b>Values:</b> <code>MINIMAL</code>, <code>STANDARD</code>, <code>FULL</code>, <code>DELETE</code></li></ul></li>
+<li><code>directory : String</code>
+</li>
+</ul></li>
+<li><code>pollOnController : boolean</code>
+</li>
+<li><code>directory : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ProxySCM'</code><div>
+<ul><li><code>projectName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PvcsScm'</code><div>
+<ul><li><code>projectRoot : String</code>
+</li>
+<li><code>archiveRoot : String</code>
+</li>
+<li><code>changeLogPrefixFudge : String</code>
+</li>
+<li><code>moduleDir : String</code>
+</li>
+<li><code>loginId : String</code>
+</li>
+<li><code>pvcsWorkspace : String</code>
+</li>
+<li><code>promotionGroup : String</code>
+</li>
+<li><code>versionLabel : String</code>
+</li>
+<li><code>cleanCopy : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RTCScm'</code><div>
+<ul><li><code>overrideGlobal : boolean</code>
+<div><div>
+ <p>The build toolkit location and Jazz Repository connection can be defined globally or overridden. If not defined globally, it must be overridden.</p>
+</div></div>
+
+</li>
+<li><code>buildTool : String</code>
+<div><div>
+ <p>The RTC build toolkit to use when performing builds. The toolkits available are defined in the system configuration (with the other tools like Ant and Java). The build toolkit is also necessary on the Master for polling and validating the job configuration unless the "Avoid using build toolkit on Master" option is enabled.</p>
+</div></div>
+
+</li>
+<li><code>serverURI : String</code>
+<div><div>
+ <p>The Jazz Repository connection URI for the Rational Team Concert (RTC) server</p>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ <p>The timeout period in seconds for Jazz repository requests made during the build.</p>
+</div></div>
+
+</li>
+<li><code>userId : String</code>
+<div><div>
+ <p>The build user id. Either credentials or a user id and password information should be supplied.</p>
+</div></div>
+
+</li>
+<li><code>password</code>
+<div><div>
+ <p>The Jazz Repository password for the build user. The use of a password is not secure, it can be easily discovered by anyone with access to this page. Credentials, a password file or a password should be supplied.</p>
+</div></div>
+
+<ul><li><b>Type:</b> <code>class hudson.util.Secret</code></li>
+</ul></li>
+<li><code>passwordFile : String</code>
+<div><div>
+ <p>The path to the file containing the obfuscated Jazz Repository password for the build user. Credentials, a password file or a password should be supplied.</p>
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>Credentials to use for the build user. A user name and password credential for the Jazz Repository should be configured.</p>
+</div></div>
+
+</li>
+<li><code>buildType</code>
+<ul><b>Nested Object</b>
+<li><code>value : String</code>
+</li>
+<li><code>buildDefinition : String</code>
+</li>
+<li><code>buildWorkspace : String</code>
+</li>
+<li><code>buildSnapshot : String</code>
+</li>
+<li><code>buildStream : String</code>
+</li>
+<li><code>acceptBeforeLoad : boolean</code> (optional)
+</li>
+<li><code>addLinksToWorkItems : boolean</code> (optional)
+</li>
+<li><code>buildSnapshotContext</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>snapshotOwnerType : String</code>
+</li>
+<li><code>processAreaOfOwningStream : String</code>
+</li>
+<li><code>owningStream : String</code>
+</li>
+<li><code>owningWorkspace : String</code>
+</li>
+</ul></li>
+<li><code>clearLoadDirectory : boolean</code> (optional)
+</li>
+<li><code>componentLoadConfig : String</code> (optional)
+</li>
+<li><code>componentsToExclude : String</code> (optional)
+</li>
+<li><code>createFoldersForComponents : boolean</code> (optional)
+</li>
+<li><code>currentSnapshotOwnerType : String</code> (optional)
+</li>
+<li><code>customizedSnapshotName : String</code> (optional)
+</li>
+<li><code>generateChangelogWithGoodBuild : boolean</code> (optional)
+</li>
+<li><code>loadDirectory : String</code> (optional)
+</li>
+<li><code>loadPolicy : String</code> (optional)
+</li>
+<li><code>overrideDefaultSnapshotName : boolean</code> (optional)
+</li>
+<li><code>pathToLoadRuleFile : String</code> (optional)
+</li>
+<li><code>pollingOnly : boolean</code> (optional)
+</li>
+<li><code>pollingOnlyData</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>snapshotUUID : String</code>
+</li>
+</ul></li>
+<li><code>processArea : String</code> (optional)
+</li>
+<li><code>useDynamicLoadRules : boolean</code> (optional)
+</li>
+</ul></li>
+<li><code>avoidUsingToolkit : boolean</code>
+<div><div>
+ <p>Where possible avoid using the Build toolkit when performing tasks on the Master. This is still in the experimental stage. You will require an RTC 5.0 server which provides some of the services used.</p>
+ <p>The Build toolkit will not be used when polling RTC and terminating the RTC Build. The toolkit is still required though. It is used for other configuration tasks on the Master (i.e. validating the connection to RTC, the build definition or workspace). It is also used for checkout tasks typically performed on agent nodes.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SCLMSCM'</code><div>
+<ul><li><code>server : String</code>
+</li>
+<li><code>port : int</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>JESINTERFACELEVEL1 : boolean</code>
+</li>
+<li><code>FTPActiveMode : boolean</code>
+</li>
+<li><code>project : String</code>
+</li>
+<li><code>alternate : String</code>
+</li>
+<li><code>group : String</code>
+</li>
+<li><code>types : String</code>
+</li>
+<li><code>custJobStep : boolean</code>
+</li>
+<li><code>JobStep : String</code>
+</li>
+<li><code>custJobHeader : boolean</code>
+</li>
+<li><code>JobHeader : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ShellScriptSCM'</code><div>
+<ul><li><code>checkoutShell : String</code>
+</li>
+<li><code>pollingShell : String</code>
+</li>
+<li><code>useCheckoutForPolling : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SimpleClearCaseSCM'</code><div>
+<ul><li><code>loadRules : String</code>
+<div><div>
+ Specify the paths to the source code inside of ClearCase VOBS. one Path for each line. For instance: 
+ <p>/vobs/structure/package/product/subproduct<br> /vobs/structure/package/product/anothersubproduct.</p>
+</div></div>
+
+</li>
+<li><code>viewname : String</code>
+<div><div>
+ The viewname which has a configured config spec. This is external to the plugin as the way the config spec can be configured in many different ways. From updating the config spec dynamically with fixed intervals to having a constant one throughout a full project life time.
+</div></div>
+
+</li>
+<li><code>branch : String</code>
+<div><div>
+ Specify which branch to follow. Not mandatory. If not set then all branches will be followed, i.e you will get notifications about changes in branches which your config specification isn't related to. Example value: main, dev etc.
+</div></div>
+
+</li>
+<li><code>filter : boolean</code>
+<div><div>
+ Filters out mkbranch and rmbranch messages in lshistory. These changes isn't relevant if you are tracking source files in a specific branch.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'StoreSCM'</code><div>
+<ul><li><code>scriptName : String</code>
+</li>
+<li><code>repositoryName : String</code>
+<div><div>
+ Specify the name of the Store repository to be checked. It is assumed that the Smalltalk image being run by the "script" property will contain any necessary repository definitions.
+</div></div>
+
+</li>
+<li><code>pundles</code>
+<div><div>
+ List the names of the top-level pundles (bundles and/or packages) to check for changes. All listed pundles and their recursive prerequisites will be checked.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pundleType</code>
+<ul><li><b>Values:</b> <code>PACKAGE</code>, <code>BUNDLE</code></li></ul></li>
+<li><code>name : String</code>
+</li>
+</ul></li>
+<li><code>versionRegex : String</code>
+<div><div>
+ Specify a Regex11-style regular expression that specifies which pundle versions to consider when checking for changes. Examples: 
+ <ul>
+  <li><b>.+</b> (the default) will match any version string</li>
+  <li><b>\d+</b> will match any integer version number</li>
+  <li><b>(7.9\s*-\s*)?\d+</b> will match any integer version number with an optional "7.9 - " prefix</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>minimumBlessingLevel : String</code>
+<div><div>
+ Choose the minimum Store blessing level that should be considered. Pundle versions with a lower blessing level will be ignored.
+</div></div>
+
+</li>
+<li><code>generateParcelBuilderInputFile : boolean</code>
+<div><div>
+ Check this if Jenkins should generate an input file for ParcelBuilder or a similar tool. A ParcelBuilder input file specifies the type, name, and version of all of the Pundles that are part of the current build.
+</div></div>
+
+</li>
+<li><code>parcelBuilderInputFilename : String</code>
+<div><div>
+ The name of the file, relative to the Jenkins workspace directory, where the input file for ParcelBuilder will be written.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SubversionSCM'</code><div>
+<div><div>
+ Checks out the source code from Subversion repositories. See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin#SubversionPlugin-Postcommithook" rel="nofollow">post-commit</a> hook set up for improved turn-around time and performance in polling.
+</div></div>
+<ul><li><code>locations</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remote : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>local : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where this module is checked out. If left empty, the last path component of the URL is used as the default, just like the svn CLI. A single period (<code>.</code>) may be used to check out the project directly into the workspace rather than into a subdirectory.
+</div></div>
+
+</li>
+<li><code>depthOption : String</code>
+<div><div>--depth option for checkout and update commands. Default value is infinity. 
+ <ul>
+  <li>empty includes only the immediate target of the operation, not any of its file or directory children.</li>
+  <li>files includes the immediate target of the operation and any of its immediate file children.</li>
+  <li>immediates includes the immediate target of the operation and any of its immediate file or directory children. The directory children will themselves be empty.</li>
+  <li>infinity includes the immediate target, its file and directory children, its children's children, and so on to full recursion.</li>
+  <li>as-it-is takes the working depth from the current working copy, allows for setting update depth manually using --set-depth option.</li>
+ </ul> More information can be found <a href="http://svnbook.red-bean.com/en/1.7/svn.advanced.sparsedirs.html" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>ignoreExternalsOption : boolean</code>
+<div><div>
+ "--ignore-externals" option will be used with svn checkout, svn update commands to disable externals definition processing. 
+ <p></p> More information can be found <a href="http://svnbook.red-bean.com/en/1.7/svn.advanced.externals.html" rel="nofollow">here</a>. <br> <b>Note:</b> there is the potential to leverage <code>svn:externals</code> to gain read access to the entire Subversion repository. This can happen if you follow the normal practice of giving Jenkins credentials with read access to the entire Subversion repository. You will also need to provide the credentials to use when checking/polling out the svn:externals using the <i>Additional Credentials</i> option.
+</div></div>
+
+</li>
+<li><code>cancelProcessOnExternalsFail : boolean</code>
+<div><div>
+ Determines if the process should be cancelled when checkout/update svn:externals failed. Will work when "Ignore externals" box is not checked. Default choice is to cancelled the process when checkout/update svn:externals failed.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>workspaceUpdater</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'CheckoutUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'NoopUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateWithCleanUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateWithRevertUpdater'</code><div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'Assembla'</code><div>
+<ul><li><code>spaceName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'BacklogRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Set the project URL of Repository Browser used with this project. Sample of URL are shown below. 
+ <ul>
+  <li>https://demo.backlog.jp/projects/DORA</li>
+ </ul>
+ <p>When no value is set, project of "Backlog URL" set above is used.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CollabNetSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ The repository browser URL for the root of the project. For example, a Java.net project called myproject would use https://myproject.dev.java.net/source/browse/myproject.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'FishEyeSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of this module in FishEye. (such as http://fisheye6.cenqua.com/browse/ant/)
+</div></div>
+
+</li>
+<li><code>rootModule : String</code>
+<div><div>
+ Specify the root Subversion module that this FishEye monitors. For example, for http://fisheye6.cenqua.com/browse/ant/, this field would be ant because it displays the directory "/ant" of the ASF repo. If FishEye is configured to display the whole SVN repository, leave this field empty.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>svnPhabricator</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PolarionRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>location : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RedmineRepositoryBrowser'</code><div>
+<ul><li><code>repositoryId : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SVNWeb'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManagerSvnRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://scm-manager.org/scm/repo/namespace/name</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Sventon'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the Sventon repository browser. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be http://somehost.com/svn/
+</div></div>
+
+</li>
+<li><code>repositoryInstance : String</code>
+<div><div>
+ Specify the Sventon repository instance name that references this subversion repository. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be local
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Sventon2'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the Sventon repository browser. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be http://somehost.com/svn/
+</div></div>
+
+</li>
+<li><code>repositoryInstance : String</code>
+<div><div>
+ Specify the Sventon repository instance name that references this subversion repository. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be local
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TeamForge'</code><div>
+<ul><li><code>connectionFactory</code>
+<ul><b>Nested Object</b>
+<li><code>url : String</code>
+<div><div>
+ <p>This should be the URL of your CollabNet TeamForge site. It should be of the form 'https://forge.collab.net'.</p>
+</div></div>
+
+</li>
+<li><code>username : String</code>
+<div><div>
+ <p>The user who will upload the files.</p>
+</div></div>
+
+</li>
+<li><code>password : String</code>
+<div><div>
+ <p>The password for the user specified above. If incorrectly given, the login to the CollabNet TeamForge server will fail.</p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>project : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'TracRepositoryBrowser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ViewSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewSVN for this repository (such as <a href="http://svn.apache.org/viewvc" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewVCRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>location : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'VisualSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of VisualSVN for this repository (such as <a href="https://demo-server.visualsvn.com/!/#tortoisesvn" rel="nofollow">https://demo-server.visualsvn.com/!/#tortoisesvn</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WebSVN'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p> Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	/trunk/myapp/src/main/web/.*\.html
+	/trunk/myapp/src/main/web/.*\.jpeg
+	/trunk/myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p> More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p>Each exclusion uses literal pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 auto_build_user
+  </pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+<li><code>excludedRevprop : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions that are marked with the given revision property (revprop) when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with the correct revprop. 
+ <p></p>This type of exclusion only works with Subversion 1.5 servers and newer. 
+ <p></p>More information on revision properties can be found <a href="http://svnbook.red-bean.com/en/1.5/svn.advanced.props.html" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>excludedCommitMessages : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions with commit messages containing any of the given regular expressions when determining if a build needs to be triggered.
+</div></div>
+
+</li>
+<li><code>includedRegions : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders that are <b><i>not</i></b> in this list when determining if a build needs to be triggered. 
+ <p></p> Each inclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p> This is useful when you need to check out an entire resource for building, but only want to do the build when a subset has changed. 
+ <p></p>
+ <pre>	/trunk/myapp/c/library1/.*
+	/trunk/myapp/c/library2/.*
+  </pre> If /trunk/myapp is checked out, the build will only occur when there are changes to either the c/library1 and c/library2 subtrees. 
+ <p></p> If there are also excluded regions specified, then a file is not ignored when it is in the included list and <b><i>not</i></b> in the excluded list. 
+ <p></p> More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>ignoreDirPropChanges : boolean</code>
+<div><div>
+ If set, Jenkins ignores svn-property only changes of directories. These changes are ignored when determining whether a build should be triggered and are removed from a build's changeset. Main usage of this property is to ignore svn:mergeinfo changes (which would otherwise e.g. lead to a complete rebuild of a maven project, in spite of incremental build option).
+</div></div>
+
+</li>
+<li><code>filterChangelog : boolean</code>
+<div><div>
+ If set Jenkins will apply the same inclusion and exclusion patterns for displaying changelog entries as it does for polling for changes. If this is disabled, changes which are excluded for polling are still displayed in the changelog.
+</div></div>
+
+</li>
+<li><code>additionalCredentials</code>
+<div><div>
+ <p>If there are additional credentials required in order to obtain a complete checkout of the source, they can be provided here.</p>
+ <p>The <strong>realm</strong> is how the repository self-identifies to a client. It usually has the following format:</p>
+ <p><code>&lt;proto://host:port&gt; Realm Name</code></p>
+ <ul>
+  <li><code>proto</code> is the protocol, e.g. <code>http</code> or <code>svn</code>.</li>
+  <li><code>host</code> is the host how it's accessed by Jenkins, e.g. as IP address <code>192.168.1.100</code>, host name <code>svnserver</code>, or host name and domain <code>svn.example.org</code>.</li>
+  <li><code>port</code> is the port, even if not explicitly specified. By default, this is <code>80</code> for HTTP, <code>443</code> for HTTPS, 3690 for the <code>svn</code> protocol.</li>
+  <li><code>Realm Name</code> is how the repository self-identifies. Common options include <code>VisualSVN Server</code>, <code>Subversion Authentication</code> or the UUID of the repository.</li>
+ </ul>
+ <p>To find out the realm, you could do any of the following:</p>
+ <ul>
+  <li>If you access the repository via HTTP or HTTPS: Open the repo in a web browser without saved credentials. It will use the <code>Realm Name</code> (see above) in the authentication dialog.</li>
+  <li>Use the command line <code>svn</code> program. 
+   <ul>
+    <li>If you don't have stored the credentials, run e.g. <code>svn info https://svnserver/repo</code> and it will tell you the realm when asking you to enter a password, e.g.: <em>Authentication realm: &lt;svn://svnserver:3690&gt; VisualSVN Server</em>.</li>
+    <li>If you have already stored the credentials to access the repository, look for the realm name in one of the files in <code>~/.subversion/auth/svn/simple</code>; it will be two lines below the line <code>svn:realmstring</code>.</li>
+   </ul></li>
+  <li>When accessing a repository via the <code>svn+ssh</code> protocol, the realm has the format <code>username@svn+ssh://host:port</code> – note that the username is <em>before</em> the <code>svn+ssh://</code> (unlike the URL used for normal SVN operations), and that there are no angle brackets and no realm name. For this protocol the default port is 22.</li>
+ </ul>
+ <p>Make sure to enter the realm <em>exactly</em> as shown, starting with a <code>&lt;</code> (except for repositories accessed via <code>svn+ssh</code> – see above).</p>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>realm : String</code>
+<div><div>
+ This is the realm that the SvnKit library associates with a specific checkout. For most Subversion servers this will typically be of the format <code>&lt;<i>scheme</i>://<i>hostname</i>(:<i>port</i>)&gt; <i>name</i></code>, while for servers accessed via <code>svn+ssh</code> it is of the format <code>(<i>username</i>@)svn+ssh://<i>hostname</i>(:<i>port</i>)</code>.
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ Select the credential from the list of relevant credentials in order to use that credential for checking out the source code.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>quietOperation : boolean</code>
+<div><div>
+ <p>Mimics subversion command line <code>--quiet</code> parameter for <strong>check out / update</strong> operations to help keep the output shorter. Prints nothing, or only summary information.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SurroundSCM'</code><div>
+<ul><li><code>server : String</code>
+</li>
+<li><code>serverPort : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+<li><code>repository : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>rsaKey</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>rsaKeyFileId : String</code> (optional)
+</li>
+<li><code>rsaKeyFilePath : String</code> (optional)
+</li>
+<li><code>rsaKeyType</code> (optional)
+<ul><li><b>Values:</b> <code>NoKey</code>, <code>Path</code>, <code>ID</code></li></ul></li>
+<li><code>rsaKeyValue : String</code> (optional)
+</li>
+</ul></li>
+<li><code>rsaKeyFileId : String</code> (optional)
+</li>
+<li><code>rsaKeyFilePath : String</code> (optional)
+<div><div>
+ Enter the full path to the RSA key file for the Surround SCM connection. Example: C:\SurroundRSAKeyFile.xml
+</div></div>
+
+</li>
+<li><code>rsaKeyPath : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'SynergySCM'</code><div>
+<ul><li><code>project : String</code>
+</li>
+<li><code>database : String</code>
+</li>
+<li><code>release : String</code>
+</li>
+<li><code>purpose : String</code>
+</li>
+<li><code>username : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>engine : String</code>
+</li>
+<li><code>oldProject : String</code>
+</li>
+<li><code>baseline : String</code>
+</li>
+<li><code>oldBaseline : String</code>
+</li>
+<li><code>ccmHome : String</code>
+</li>
+<li><code>remoteClient : boolean</code>
+</li>
+<li><code>detectConflict : boolean</code>
+</li>
+<li><code>replaceSubprojects : boolean</code>
+</li>
+<li><code>checkForUpdateWarnings : boolean</code>
+</li>
+<li><code>leaveSessionOpen : boolean</code>
+</li>
+<li><code>maintainWorkarea : boolean</code>
+</li>
+<li><code>checkTaskModifiedObjects : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'VaultSCM'</code><div>
+<ul><li><code>serverName : String</code>
+<div><div>
+ Specify the hostname or IP address of the vault server.
+</div></div>
+
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>userName : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryName : String</code>
+</li>
+<li><code>vaultName : String</code>
+</li>
+<li><code>sslEnabled : boolean</code>
+</li>
+<li><code>useNonWorkingFolder : boolean</code>
+</li>
+<li><code>merge : String</code>
+</li>
+<li><code>fileTime : String</code>
+</li>
+<li><code>makeWritableEnabled : boolean</code>
+</li>
+<li><code>verboseEnabled : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'hudson.plugins.gradle_repo.RepoScm'</code><div>
+<ul><li><code>repositoryUrl : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'hudson.plugins.repo.RepoScm'</code><div>
+<div><div>
+ <p>The <a href="https://plugins.jenkins.io/repo/" rel="nofollow">repo plugin</a> provides <a href="https://gerrit.googlesource.com/git-repo" rel="nofollow">Repo</a> as an SCM tools in Jenkins.</p>
+ <p>The repo plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step" rel="nofollow"><code>checkout</code></a> step. The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator" rel="nofollow"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select repo plugin checkout options and provides online help for each of the options.</p>
+</div></div>
+<ul><li><code>manifestRepositoryUrl : String</code>
+<div><div>
+ <p>The URL of the manifest. This is passed to repo as <code>repo init -u <i>url</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>cleanFirst : boolean</code> (optional)
+<div><div>
+ <p>When this is checked the first thing to do will be a</p>
+ <pre>repo forall -c "git clean -fdx"</pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>currentBranch : boolean</code> (optional)
+<div><div>
+ <p>Fetch only the current branch from server. Increases the speed of the repo sync operation. This is passed to repo as <code>repo init <i>--current-branch</i></code> and <code>repo sync <i>-c</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ <p>Specify the depth in history to sync from the source. The default is to sync all of the history. Use 1 to just sync the most recent commit. This is passed to repo as <code>repo init --depth=<i>n</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>destinationDir : String</code> (optional)
+<div><div>
+ <p>The sub-directory of the workspace where the source should be synced. The default is the root of the workspace.</p>
+</div></div>
+
+</li>
+<li><code>extraEnvVars</code> (optional)
+<ul><li><b>Type:</b> <code>java.util.Map&lt;java.lang.String, java.lang.String&gt;</code></li>
+</ul></li>
+<li><code>fetchSubmodules : boolean</code> (optional)
+<div><div>
+ <p>Fetch submodules for from server. This is passed to repo as <code>repo sync <i>--fetch-submodules</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>forceSync : boolean</code> (optional)
+<div><div>
+ <p>Overwrite an existing git directory if it needs to point to a different object directory. WARNING: this may cause loss of data. This is passed to repo as <code>repo sync <i>--force-sync</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>ignoreProjects : String</code> (optional)
+</li>
+<li><code>jobs : int</code> (optional)
+<div><div>
+ <p>Specify the number of projects to fetch simultaneously. The default is 1. This is passed to repo as <code>repo sync --jobs=<i>n</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>localManifest : String</code> (optional)
+<div><div>
+ <p>The contents of <code>.repo/local_manifests/local.xml</code>. This is written prior to calling sync. The default is to not use a <code>local.xml</code> file.</p>
+ <p>The contents may be given here literally, as XML; see the example below. Such literal content <b>must</b> start with the string <code>&lt;?xml</code>. Alternatively, the content may be given as an URL, in which case the file pointed by the URL is used. If the content does not start with the <code>&lt;?xml</code> prefix, it is assumed to be an URL.</p>
+ <p><b>An example</b></p>
+ <pre>    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    &lt;manifest&gt;
+      &lt;project path="external/project" name="org/project" remote="github" revision="master" /&gt;
+    &lt;/manifest&gt;
+  </pre>
+</div></div>
+
+</li>
+<li><code>manifestBranch : String</code> (optional)
+<div><div>
+ <p>The branch of the manifest to use. This is passed to repo as <code>repo init -b <i>branchname</i></code>. Repo will default to <i>master</i> if a branch name isn't provided.</p>
+</div></div>
+
+</li>
+<li><code>manifestFile : String</code> (optional)
+<div><div>
+ <p>The initial manifest file to use while initializing the repo. This is passed to repo as <code>repo init -m <i>manifestFile</i></code>. If a manifest file is not specified, repo uses the default of "default.xml".</p>
+</div></div>
+
+</li>
+<li><code>manifestGroup : String</code> (optional)
+<div><div>
+ <p>Restricts manifest projects to ones tagged with provided group name. This is passed to repo as <code>repo init -g <i>groupName</i></code>. If a group name is not provided, the <code>-g</code> option is not passed to repo and it will default to fetching projects that are tagged with 'default'.</p>
+</div></div>
+
+</li>
+<li><code>manifestPlatform : String</code> (optional)
+<div><div>
+ <p>Restrict manifest projects to ones with a specified platform group <code>[auto|all|none|linux|darwin|...]</code> This is passed to repo as <code>repo init -P <i>platformName</i></code>. If a platform is not provided, the <code>-p</code> option is not passed to repo and it will default to <code>auto</code> and ony fetch projects which needed for current system.</p>
+</div></div>
+
+</li>
+<li><code>manifestSubmodules : boolean</code> (optional)
+<div><div>
+ <p>Sync any submodules associated with the manifest repo. This is passed to repo as <code>repo init <i>--submodules</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>mirrorDir : String</code> (optional)
+<div><div>
+ <p>The location of the mirror directory to reference when initialising the repository. This is passed to repo as <code>repo sync --reference=<i>DIR</i></code>. This speeds up fetching code and isn't used by default.</p>
+</div></div>
+
+</li>
+<li><code>noCloneBundle : boolean</code> (optional)
+<div><div>
+ <p>When this is checked <code>--no-clone-bundle</code> is used when running the <code>repo init</code> and <code>repo sync</code> commands.</p>
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code> (optional)
+<div><div>
+ <p>Don't fetch tags. This is passed to repo as <code>repo init <i>--no-tags</i></code> and <code>repo sync <i>--no-tags</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>quiet : boolean</code> (optional)
+<div><div>
+ <p>Make repo more quiet. This is passed to repo as <code>repo sync <i>-q</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>repoBranch : String</code> (optional)
+<div><div>
+ <p>Use a specific branch for pulling repo itself. By default this is empty, and repo will be using its default branch (i.e. stable)</p>
+</div></div>
+
+</li>
+<li><code>repoUrl : String</code> (optional)
+<div><div>
+ <p>Pull repo itself from this git repository. By default this is empty, and repo will be pulled from its default git url (i.e. googles)</p>
+</div></div>
+
+</li>
+<li><code>resetFirst : boolean</code> (optional)
+<div><div>
+ <p>When this is checked the first thing to do will be a</p>
+ <pre>repo forall -c "git reset --hard"</pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>showAllChanges : boolean</code> (optional)
+<div><div>
+ <p>When this is checked <code>--first-parent</code> is no longer passed to <code>git log</code> when determining changesets.</p>
+</div></div>
+
+</li>
+<li><code>trace : boolean</code> (optional)
+<div><div>
+ <p>Trace git command execution. This is passed to repo as <code>repo <i>--trace</i> &lt;subcommand&gt;</code>.</p>
+</div></div>
+
+</li>
+<li><code>worktree : boolean</code> (optional)
+<div><div>
+ <p>Use `git worktree` for checkouts (At least, Git version 2.15 is required to avoid dangerous gc bugs). Usefull under Windows because it no longer require symlinks at all.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>none</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'OpenShiftImageStreams'</code><div>
+<ul><li><code>imageStreamName : String</code>
+<div><div>
+ The name of the ImageStream is what shows up in the NAME column if you dump all the ImageStream's with the `oc get is` command invocation.
+</div></div>
+
+</li>
+<li><code>tag : String</code>
+<div><div>
+ The specific image tag within the ImageStream to monitor.
+</div></div>
+
+</li>
+<li><code>apiURL : String</code>
+</li>
+<li><code>namespace : String</code>
+</li>
+<li><code>authToken : String</code>
+</li>
+<li><code>verbose : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PdsConfiguration'</code><div>
+<ul><li><code>connectionId : String</code>
+</li>
+<li><code>filterPattern : String</code>
+</li>
+<li><code>fileExtension : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>targetFolder : String</code>
+</li>
+</ul></div></li>
+<li><code>perforce</code><div>
+<ul><li><code>credential : String</code>
+<div><div><b>Perforce Credentials</b>
+ <p>Select the appropriate credential for the Perforce connection. Perforce Credentials are defined in the Jenkins Credentials plugin <a rel="nofollow">here</a>.</p>
+ <p>There are two types:</p>
+ <ul>
+  <li>'Perforce Password Credential' for standard username/password authentication</li>
+  <li>'Perforce Ticket Credential' for ticket based authentication.</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>workspace</code>
+<div><div><b>Workspace Behaviour</b>
+ <p>Select the appropriate Perforce workspace behaviour from the list. Not all modes will suit all Jenkins Job build types.</p>
+ <p>There are five types:</p>
+ <ul>
+  <dt>
+   Manual
+  </dt>
+  <dd>
+   Manually define the Workspace view and sync options. Existing workspace will by updated or a new workspace created.
+  </dd>
+  <dt>
+   Spec File
+  </dt>
+  <dd>
+   Use a pre-defined Workspace Spec file versioned in Perforce.
+  </dd>
+  <dt>
+   Static
+  </dt>
+  <dd>
+   Use a pre-defined Workspace; must already exist and have a valid view.
+  </dd>
+  <dt>
+   Streams
+  </dt>
+  <dd>
+   Auto create/update a Streams workspace with a view determined by the chosen stream.
+  </dd>
+  <dt>
+   Template
+  </dt>
+  <dd>
+   Auto create/update a normal workspace with a view determined by the template workspace.
+  </dd>
+ </ul>
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>manualSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>Workspace name</b>
+ <p>Specify the name of the Perforce workspace to be used as the Jenkins build workspace. If the workspace does not yet exist, the configuration will be saved in Jenkins; the workspace is created only when it is to be used. If the workspace exists and you are connected to a Perforce server the auto-text fill should list suitable workspaces; updates are only applied when the workspace is used.</p>
+</div></div>
+
+</li>
+<li><code>spec</code>
+<ul><b>Nested Object</b>
+<li><code>allwrite : boolean</code>
+</li>
+<li><code>clobber : boolean</code>
+</li>
+<li><code>compress : boolean</code>
+</li>
+<li><code>locked : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>rmdir : boolean</code>
+</li>
+<li><code>streamName : String</code>
+</li>
+<li><code>line : String</code>
+<div><div><b>Line Endings</b>
+ <p>Set line-ending character(s) for client text files.</p>
+ <ul>
+  <li><b>UNIX</b> <p>linefeed: UNIX style.</p></li>
+  <li><b>MAC</b> <p>carriage return: Macintosh style. (obsolete)</p></li>
+  <li><b>WIN</b> <p>carriage return-linefeed: Windows style.</p></li>
+  <li><b>SHARE</b> <p>hybrid: writes UNIX style but reads UNIX, Mac or Windows style.</p></li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>view : String</code>
+<div><div><b>View</b>
+ <p>Lines to map depot files into the client workspace.</p>
+ <p>The variable ${P4_CLIENT} will expand to the client name, for example, a simple mapping:</p>
+ <p>//depot/... //${P4_CLIENT}/...</p>
+ <p>Maps files in the depot to files in your client workspace. Defines the files that you want in your client workspace and specifies where you want them to reside. The default view maps all depot files onto the client. See 'p4 help views' for view syntax. A new view takes effect on the next 'p4 sync'.</p>
+ <p>To support migration from the old Perforce plugin, a View Mapping can be inserted from a file in Perforce. Add the depot path to the "View Mappings" field Prefix "@" (this only applies to the "Manual" Workspace behaviour).</p>
+</div></div>
+
+</li>
+<li><code>changeView : String</code>
+</li>
+<li><code>type : String</code>
+<div><div><b>Type</b>
+ <p>Type of client: writeable/readonly/partitioned/graph</p>
+ <p>By default all clients are 'writeable', certain clients are short lived and perform long sync and build cycles. Over time these build clients can fragment the 'db.have' table which is used to track what files a client has synced. Setting a type of 'readonly' gives the client its own personal 'db.have' database table. A 'readonly' client cannot 'edit' or 'submit' files, however for build automation this is not usually a requirement and the performance tradeoff is worth considering if your build automation is causing issues with the 'db.have' table. This option requires that an administrator has first configured the 'client.readonly.dir' setting. If it is necessary to submit changes as part of your build, you may specify a 'partitioned' client: like a 'reaonly' client, this type also has a separate 'db.have' table under the 'client.readonly.dir' directory, but allows journalled 'edit' and 'submit' of files.</p>
+</div></div>
+
+</li>
+<li><code>serverID : String</code>
+</li>
+<li><code>backup : boolean</code>
+<div><div><b>Backup</b>
+ <p>Client's participation in backup enable/disable. If not specified backup of a writable client defaults to enabled.</p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>cleanup : boolean</code>
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>specFileSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>An existing workspace</b>
+ <p>Specify the name of the Perforce workspace to be used as the Jenkins build workspace. If the workspace does not yet exist, the configuration will be saved in Jenkins; the workspace is created only when it is to be used. If the workspace exists and you are connected to a Perforce server the auto-text fill should list suitable workspaces; updates are only applied when the workspace is used.</p>
+</div></div>
+
+</li>
+<li><code>specPath : String</code>
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>staticSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>name : String</code>
+<div><div><b>An existing workspace</b>
+ <p>Specify the name of an existing workspace in Perforce to be used as the Jenkins build workspace. If connected to a Perforce server the auto-text fill should list suitable workspaces</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>streamSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>streamName : String</code>
+<div><div><b>Stream codeline</b>
+ <p>Specify the full Perforce depot path for the given stream. If connected to a Perforce server the auto-text fill should list possible streams.</p> <i>For example: //stream-depot/main-stream</i>
+</div></div>
+
+</li>
+<li><code>format : String</code>
+<div><div><b>Workspace name formatter</b>
+ <p>Jenklin slave nodes must each use a unique Perforce workspace. The format string configures the workspace name by substituting the specified variables: (at least one variable must be used)</p>
+ <p>Variables can be taken from the Jenkins <a rel="nofollow">Environment</a> or Parameterized builds</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>templateSpec</code><div>
+<ul><li><code>charset : String</code>
+<div><div><b>P4CHARSET</b>
+ <p>The character set used by Jenkins when syncing files from the Perforce server. This should be set to 'none' unless connected to a Unicode enabled Perforce server.</p>
+</div></div>
+
+</li>
+<li><code>pinHost : boolean</code>
+</li>
+<li><code>templateName : String</code>
+<div><div><b>Templace workspace</b>
+ <p>Specify the name of an existing workspace in Perforce used to create or update a Jenkins build workspace. If connected to a Perforce server the auto-text fill should list suitable workspaces</p>
+</div></div>
+
+</li>
+<li><code>format : String</code>
+<div><div><b>Workspace name formatter</b>
+ <p>Jenklin slave nodes must each use a unique Perforce workspace. The format string configures the workspace name by substituting the specified variables: (at least one variable must be used)</p>
+ <p>Variables can be taken from the Jenkins <a rel="nofollow">Environment</a> or Parameterized builds</p>
+</div></div>
+
+</li>
+<li><code>syncID : String</code> (optional)
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>filter</code>
+<ul><b>Array / List of Nested Choice of Objects</b>
+<li><code>latest</code><div>
+<ul><li><code>latestChange : boolean</code>
+</li>
+</ul></div></li>
+<li><code>pathFilter</code><div>
+<ul><li><code>path : String</code>
+<div><div><b>Depot path filter</b>
+ <p>Changes can be filtered to not trigger a build; if all the files within a change match the specified path, the build is filtered.</p>
+ <p>For example, with a Filter of " <code>//depot/main/tests</code> ":</p>
+ <p><strong>Case A</strong> (change will be filtered):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/index.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+  <li><code>//depot/main/tests/002/test.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (change will not be filtered, as build.xml is outside of the filter):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+  <li><code>//depot/main/tests/004/test.xml</code></li>
+  <li><code>//depot/main/tests/005/test.xml</code></li>
+ </ul>
+ <p>This is not Perforce syntax. Use of ... and * patterns are not supported. Only paths to directories are supported.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>viewPattern</code><div>
+<ul><li><code>patternText : String</code>
+<div><div><b>Java Pattern filter</b>
+ <p>Changes can be filtered to not trigger a build; if none of the files within a change match a Java pattern (regular expression) listed, the build is filtered.</p>
+ <p>For example, with the following regular expressions: <br> <code>//depot/main/tests.*</code> <br> <code>//depot/main/src/.*\.cpp</code> <br> <code>//depot/main/build/.*(?:\.rb|\.py|\.bat|Jenkinsfile)</code> <br> <code>//depot/main/lib/(?!Lib1|Lib2).*</code> <br></p>
+ <p><strong>Case A</strong> (change will not be filtered, as these files match our first pattern on "tests"):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/CONTRIUBTING.md</code></li>
+  <li><code>//depot/main/tests/001/index.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (Be careful with incomplete file paths! Change will NOT be filtered, <br>as this file matches a pattern which was likely intended as describing a <strong>"tests/"</strong> directory.)</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests.doc</code></li>
+ </ul>
+ <p><strong>Case C</strong> (change will NOT be filtered, as all files match our fourth pattern looking for script files in 'build/'):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/build/rbs/deploy_server.rb</code></li>
+  <li><code>//depot/main/build/deploy/deploy.bat</code></li>
+  <li><code>//depot/main/build/Jenkinsfile</code></li>
+ </ul>
+ <p><strong>Case D</strong> (change will be filtered, as no file matches our second pattern for ".cpp" files under "main/src"):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/howto.doc</code></li>
+  <li><code>//depot/main/src/oldmain.c</code></li>
+  <li><code>//depot/main/src/art/splash.bmp</code></li>
+  <li><code>//depot/main/src/bt/funnelcake.php</code></li>
+ </ul>
+ <p><strong>Case E</strong> (change will be filtered. Lib1 is included in a negative lookahead, and thus is excluded.)</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/lib/Lib1/build.xml</code></li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>caseSensitive : boolean</code>
+</li>
+</ul></div></li>
+<li><code>incremental</code><div>
+<ul><li><code>perChange : boolean</code>
+<div><div><b>Polling per change</b>
+ <p>When enabled, only the one, oldest changelist returned by polling is built.</p>
+ <p>If <code>P4_INCREMENTAL</code> environment variable (or build parameter) is set to "false", polling per change is ignored and all changelists are built.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>userFilter</code><div>
+<ul><li><code>user : String</code>
+<div><div><b>User name filter</b>
+ <p>Changes can be filtered to not trigger a build; if the owner of a change matches the specified name, the build is filtered.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>viewFilter</code><div>
+<ul><li><code>viewMask : String</code>
+<div><div><b>View Mask filter</b>
+ <p>Changes can be filtered to not trigger a build; if none of the files within a change are contained in the view mask, the build is filtered.</p>
+ <p>For example, with a View Mask Filter of: <br> <code>//depot/main/tests</code> <br> <code>-//depot/main/tests/001</code> <br></p>
+ <p><strong>Case A</strong> (change will not be filtered, as index.xml is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/tests/index.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+ </ul>
+ <p><strong>Case B</strong> (change will not be filtered, as index.xml is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/test/index.xml</code></li>
+  <li><code>//depot/main/src/build.xml</code></li>
+ </ul>
+ <p><strong>Case C</strong> (change will be filtered, as no file is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+ </ul>
+ <p><strong>Case D</strong> (change will be filtered, as no file is in the view mask):</p>
+ <p>Files:</p>
+ <ul>
+  <li><code>//depot/main/src/build.xml</code></li>
+  <li><code>//depot/main/tests/001/test.xml</code></li>
+ </ul>
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>populate</code>
+<div><div><b>Populate Options</b>
+ <p>Perforce will populate the workspace with the file revisions needed for the build. The different options effect the way the workspace is cleaned and the file revisions are updated.</p>
+ <p>There are three options:</p>
+ <ul>
+  <dt>
+   Automatic Cleanup and Sync
+  </dt>
+  <dd>
+   Efficient cleaning and syncing of file revisions. Extra (non versioned files) are removed, missing and modified files re-added. <br>Best for clean builds.
+  </dd>
+  <dt>
+   Flush Workspace
+  </dt>
+  <dd>
+   No files Sync or cleanup attempted, but the Workspace's have list is updated. <br>Effective command 'p4 sync -k'.
+  </dd>
+  <dt>
+   Force Clean and Sync
+  </dt>
+  <dd>
+   Will remove all files from under the workspace root, then force sync the required files. Inefficient and NOT RECOMENDED.
+  </dd>
+  <dt>
+   Graph Force Clean and Sync/dt&gt;
+  </dt>
+  <dd>
+   For Graph and Hybrid only, will remove all files from under the workspace root, then force sync the required files.
+  </dd>
+  <dt>
+   Preview Check Only
+  </dt>
+  <dd>
+   No files Sync or cleanup attempted; the Workspace's have list is not updated. <br>Effective command 'p4 sync -n'.
+  </dd>
+  <dt>
+   Sync Only
+  </dt>
+  <dd>
+   No cleanup attempted; the sync will update all files (as CLOBBER is set) to the required set of revisions. <br>Best for incremental builds.
+  </dd>
+ </ul>
+</div></div>
+
+<ul><b>Nested Choice of Objects</b>
+<li><code>autoClean</code><div>
+<ul><li><code>replace : boolean</code>
+<div><div><b>REPLACE missing/modified files</b>
+ <p>Perforce will check out and overwrite any depot files which are either missing from workspace, or have been modified locally.</p>
+</div></div>
+
+</li>
+<li><code>delete : boolean</code>
+<div><div><b>DELETE generated files</b>
+ <p>Perforce will delete any local files that are not in the depot.</p>
+</div></div>
+
+</li>
+<li><code>tidy : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>previewOnly</code><div>
+<ul><li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+</li>
+</ul></div></li>
+<li><code>flushOnly</code><div>
+<ul><li><code>quiet : boolean</code>
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will flush only to the specified label or changelist number. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>forceClean</code><div>
+<ul><li><code>have : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>graphClean</code><div>
+<ul><li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+<li><code>syncOnly</code><div>
+<ul><li><code>revert : boolean</code>
+</li>
+<li><code>have : boolean</code>
+</li>
+<li><code>force : boolean</code>
+</li>
+<li><code>modtime : boolean</code>
+</li>
+<li><code>quiet : boolean</code>
+<div><div><b>Suppressing info messages</b>
+ <p>Enables the -q flag for all applicable Perforce operations. Summary details will still be displayed.</p>
+</div></div>
+
+</li>
+<li><code>pin : String</code>
+<div><div><b>Pinning a build at Perforce Label</b>
+ <p>When a build is triggered by Polling, Build Now or an external Action, the workspace will sync only to the specified label. Any other specified change or label will be ignored.</p>
+ <p>Supports variable expansion e.g. ${VAR}. If 'now' is used, or a variable that expands to 'now', then the latest change is used (within the scope of the workspace view).</p>
+</div></div>
+
+</li>
+<li><code>parallel</code>
+<ul><b>Nested Object</b>
+<li><code>enable : boolean</code>
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>threads : String</code>
+</li>
+<li><code>minfiles : String</code>
+</li>
+<li><code>minbytes : String</code>
+</li>
+</ul></li>
+</ul></div></li>
+</ul></li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>fishEye</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>rootModule : String</code>
+</li>
+</ul></div></li>
+<li><code>openGrok</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>depotPath : String</code>
+</li>
+<li><code>projectName : String</code>
+</li>
+</ul></div></li>
+<li><code>p4Web</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>swarm</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+</ul></div></li>
+<li><code>$class: 'PlasticSCM'</code><div>
+<ul><li><code>selector : String</code>
+</li>
+<li><code>cleanup</code>
+<ul><li><b>Values:</b> <code>MINIMAL</code>, <code>STANDARD</code>, <code>FULL</code>, <code>DELETE</code></li></ul></li>
+<li><code>workingMode</code>
+<ul><li><b>Values:</b> <code>NONE</code>, <code>UP</code>, <code>LDAP</code></li></ul></li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>useMultipleWorkspaces : boolean</code>
+</li>
+<li><code>additionalWorkspaces</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>selector : String</code>
+</li>
+<li><code>cleanup</code>
+<ul><li><b>Values:</b> <code>MINIMAL</code>, <code>STANDARD</code>, <code>FULL</code>, <code>DELETE</code></li></ul></li>
+<li><code>directory : String</code>
+</li>
+</ul></li>
+<li><code>pollOnController : boolean</code>
+</li>
+<li><code>directory : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ProxySCM'</code><div>
+<ul><li><code>projectName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PvcsScm'</code><div>
+<ul><li><code>projectRoot : String</code>
+</li>
+<li><code>archiveRoot : String</code>
+</li>
+<li><code>changeLogPrefixFudge : String</code>
+</li>
+<li><code>moduleDir : String</code>
+</li>
+<li><code>loginId : String</code>
+</li>
+<li><code>pvcsWorkspace : String</code>
+</li>
+<li><code>promotionGroup : String</code>
+</li>
+<li><code>versionLabel : String</code>
+</li>
+<li><code>cleanCopy : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RTCScm'</code><div>
+<ul><li><code>overrideGlobal : boolean</code>
+<div><div>
+ <p>The build toolkit location and Jazz Repository connection can be defined globally or overridden. If not defined globally, it must be overridden.</p>
+</div></div>
+
+</li>
+<li><code>buildTool : String</code>
+<div><div>
+ <p>The RTC build toolkit to use when performing builds. The toolkits available are defined in the system configuration (with the other tools like Ant and Java). The build toolkit is also necessary on the Master for polling and validating the job configuration unless the "Avoid using build toolkit on Master" option is enabled.</p>
+</div></div>
+
+</li>
+<li><code>serverURI : String</code>
+<div><div>
+ <p>The Jazz Repository connection URI for the Rational Team Concert (RTC) server</p>
+</div></div>
+
+</li>
+<li><code>timeout : int</code>
+<div><div>
+ <p>The timeout period in seconds for Jazz repository requests made during the build.</p>
+</div></div>
+
+</li>
+<li><code>userId : String</code>
+<div><div>
+ <p>The build user id. Either credentials or a user id and password information should be supplied.</p>
+</div></div>
+
+</li>
+<li><code>password</code>
+<div><div>
+ <p>The Jazz Repository password for the build user. The use of a password is not secure, it can be easily discovered by anyone with access to this page. Credentials, a password file or a password should be supplied.</p>
+</div></div>
+
+<ul><li><b>Type:</b> <code>class hudson.util.Secret</code></li>
+</ul></li>
+<li><code>passwordFile : String</code>
+<div><div>
+ <p>The path to the file containing the obfuscated Jazz Repository password for the build user. Credentials, a password file or a password should be supplied.</p>
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ <p>Credentials to use for the build user. A user name and password credential for the Jazz Repository should be configured.</p>
+</div></div>
+
+</li>
+<li><code>buildType</code>
+<ul><b>Nested Object</b>
+<li><code>value : String</code>
+</li>
+<li><code>buildDefinition : String</code>
+</li>
+<li><code>buildWorkspace : String</code>
+</li>
+<li><code>buildSnapshot : String</code>
+</li>
+<li><code>buildStream : String</code>
+</li>
+<li><code>acceptBeforeLoad : boolean</code> (optional)
+</li>
+<li><code>addLinksToWorkItems : boolean</code> (optional)
+</li>
+<li><code>buildSnapshotContext</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>snapshotOwnerType : String</code>
+</li>
+<li><code>processAreaOfOwningStream : String</code>
+</li>
+<li><code>owningStream : String</code>
+</li>
+<li><code>owningWorkspace : String</code>
+</li>
+</ul></li>
+<li><code>clearLoadDirectory : boolean</code> (optional)
+</li>
+<li><code>componentLoadConfig : String</code> (optional)
+</li>
+<li><code>componentsToExclude : String</code> (optional)
+</li>
+<li><code>createFoldersForComponents : boolean</code> (optional)
+</li>
+<li><code>currentSnapshotOwnerType : String</code> (optional)
+</li>
+<li><code>customizedSnapshotName : String</code> (optional)
+</li>
+<li><code>generateChangelogWithGoodBuild : boolean</code> (optional)
+</li>
+<li><code>loadDirectory : String</code> (optional)
+</li>
+<li><code>loadPolicy : String</code> (optional)
+</li>
+<li><code>overrideDefaultSnapshotName : boolean</code> (optional)
+</li>
+<li><code>pathToLoadRuleFile : String</code> (optional)
+</li>
+<li><code>pollingOnly : boolean</code> (optional)
+</li>
+<li><code>pollingOnlyData</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>snapshotUUID : String</code>
+</li>
+</ul></li>
+<li><code>processArea : String</code> (optional)
+</li>
+<li><code>useDynamicLoadRules : boolean</code> (optional)
+</li>
+</ul></li>
+<li><code>avoidUsingToolkit : boolean</code>
+<div><div>
+ <p>Where possible avoid using the Build toolkit when performing tasks on the Master. This is still in the experimental stage. You will require an RTC 5.0 server which provides some of the services used.</p>
+ <p>The Build toolkit will not be used when polling RTC and terminating the RTC Build. The toolkit is still required though. It is used for other configuration tasks on the Master (i.e. validating the connection to RTC, the build definition or workspace). It is also used for checkout tasks typically performed on agent nodes.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SCLMSCM'</code><div>
+<ul><li><code>server : String</code>
+</li>
+<li><code>port : int</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>JESINTERFACELEVEL1 : boolean</code>
+</li>
+<li><code>FTPActiveMode : boolean</code>
+</li>
+<li><code>project : String</code>
+</li>
+<li><code>alternate : String</code>
+</li>
+<li><code>group : String</code>
+</li>
+<li><code>types : String</code>
+</li>
+<li><code>custJobStep : boolean</code>
+</li>
+<li><code>JobStep : String</code>
+</li>
+<li><code>custJobHeader : boolean</code>
+</li>
+<li><code>JobHeader : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ShellScriptSCM'</code><div>
+<ul><li><code>checkoutShell : String</code>
+</li>
+<li><code>pollingShell : String</code>
+</li>
+<li><code>useCheckoutForPolling : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SimpleClearCaseSCM'</code><div>
+<ul><li><code>loadRules : String</code>
+<div><div>
+ Specify the paths to the source code inside of ClearCase VOBS. one Path for each line. For instance: 
+ <p>/vobs/structure/package/product/subproduct<br> /vobs/structure/package/product/anothersubproduct.</p>
+</div></div>
+
+</li>
+<li><code>viewname : String</code>
+<div><div>
+ The viewname which has a configured config spec. This is external to the plugin as the way the config spec can be configured in many different ways. From updating the config spec dynamically with fixed intervals to having a constant one throughout a full project life time.
+</div></div>
+
+</li>
+<li><code>branch : String</code>
+<div><div>
+ Specify which branch to follow. Not mandatory. If not set then all branches will be followed, i.e you will get notifications about changes in branches which your config specification isn't related to. Example value: main, dev etc.
+</div></div>
+
+</li>
+<li><code>filter : boolean</code>
+<div><div>
+ Filters out mkbranch and rmbranch messages in lshistory. These changes isn't relevant if you are tracking source files in a specific branch.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'StoreSCM'</code><div>
+<ul><li><code>scriptName : String</code>
+</li>
+<li><code>repositoryName : String</code>
+<div><div>
+ Specify the name of the Store repository to be checked. It is assumed that the Smalltalk image being run by the "script" property will contain any necessary repository definitions.
+</div></div>
+
+</li>
+<li><code>pundles</code>
+<div><div>
+ List the names of the top-level pundles (bundles and/or packages) to check for changes. All listed pundles and their recursive prerequisites will be checked.
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>pundleType</code>
+<ul><li><b>Values:</b> <code>PACKAGE</code>, <code>BUNDLE</code></li></ul></li>
+<li><code>name : String</code>
+</li>
+</ul></li>
+<li><code>versionRegex : String</code>
+<div><div>
+ Specify a Regex11-style regular expression that specifies which pundle versions to consider when checking for changes. Examples: 
+ <ul>
+  <li><b>.+</b> (the default) will match any version string</li>
+  <li><b>\d+</b> will match any integer version number</li>
+  <li><b>(7.9\s*-\s*)?\d+</b> will match any integer version number with an optional "7.9 - " prefix</li>
+ </ul>
+</div></div>
+
+</li>
+<li><code>minimumBlessingLevel : String</code>
+<div><div>
+ Choose the minimum Store blessing level that should be considered. Pundle versions with a lower blessing level will be ignored.
+</div></div>
+
+</li>
+<li><code>generateParcelBuilderInputFile : boolean</code>
+<div><div>
+ Check this if Jenkins should generate an input file for ParcelBuilder or a similar tool. A ParcelBuilder input file specifies the type, name, and version of all of the Pundles that are part of the current build.
+</div></div>
+
+</li>
+<li><code>parcelBuilderInputFilename : String</code>
+<div><div>
+ The name of the file, relative to the Jenkins workspace directory, where the input file for ParcelBuilder will be written.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SubversionSCM'</code><div>
+<div><div>
+ Checks out the source code from Subversion repositories. See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin#SubversionPlugin-Postcommithook" rel="nofollow">post-commit</a> hook set up for improved turn-around time and performance in polling.
+</div></div>
+<ul><li><code>locations</code>
+<ul><b>Array / List of Nested Object</b>
+<li><code>remote : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>local : String</code>
+<div><div>
+ Specify a local directory (relative to <a rel="nofollow">the workspace root</a>) where this module is checked out. If left empty, the last path component of the URL is used as the default, just like the svn CLI. A single period (<code>.</code>) may be used to check out the project directly into the workspace rather than into a subdirectory.
+</div></div>
+
+</li>
+<li><code>depthOption : String</code>
+<div><div>--depth option for checkout and update commands. Default value is infinity. 
+ <ul>
+  <li>empty includes only the immediate target of the operation, not any of its file or directory children.</li>
+  <li>files includes the immediate target of the operation and any of its immediate file children.</li>
+  <li>immediates includes the immediate target of the operation and any of its immediate file or directory children. The directory children will themselves be empty.</li>
+  <li>infinity includes the immediate target, its file and directory children, its children's children, and so on to full recursion.</li>
+  <li>as-it-is takes the working depth from the current working copy, allows for setting update depth manually using --set-depth option.</li>
+ </ul> More information can be found <a href="http://svnbook.red-bean.com/en/1.7/svn.advanced.sparsedirs.html" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>ignoreExternalsOption : boolean</code>
+<div><div>
+ "--ignore-externals" option will be used with svn checkout, svn update commands to disable externals definition processing. 
+ <p></p> More information can be found <a href="http://svnbook.red-bean.com/en/1.7/svn.advanced.externals.html" rel="nofollow">here</a>. <br> <b>Note:</b> there is the potential to leverage <code>svn:externals</code> to gain read access to the entire Subversion repository. This can happen if you follow the normal practice of giving Jenkins credentials with read access to the entire Subversion repository. You will also need to provide the credentials to use when checking/polling out the svn:externals using the <i>Additional Credentials</i> option.
+</div></div>
+
+</li>
+<li><code>cancelProcessOnExternalsFail : boolean</code>
+<div><div>
+ Determines if the process should be cancelled when checkout/update svn:externals failed. Will work when "Ignore externals" box is not checked. Default choice is to cancelled the process when checkout/update svn:externals failed.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>workspaceUpdater</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'CheckoutUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'NoopUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateWithCleanUpdater'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'UpdateWithRevertUpdater'</code><div>
+<ul></ul></div></li>
+</ul></li>
+<li><code>browser</code>
+<ul><b>Nested Choice of Objects</b>
+<li><code>$class: 'Assembla'</code><div>
+<ul><li><code>spaceName : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'BacklogRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Set the project URL of Repository Browser used with this project. Sample of URL are shown below. 
+ <ul>
+  <li>https://demo.backlog.jp/projects/DORA</li>
+ </ul>
+ <p>When no value is set, project of "Backlog URL" set above is used.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'CollabNetSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ The repository browser URL for the root of the project. For example, a Java.net project called myproject would use https://myproject.dev.java.net/source/browse/myproject.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'FishEyeSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of this module in FishEye. (such as http://fisheye6.cenqua.com/browse/ant/)
+</div></div>
+
+</li>
+<li><code>rootModule : String</code>
+<div><div>
+ Specify the root Subversion module that this FishEye monitors. For example, for http://fisheye6.cenqua.com/browse/ant/, this field would be ant because it displays the directory "/ant" of the ASF repo. If FishEye is configured to display the whole SVN repository, leave this field empty.
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>svnPhabricator</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'PolarionRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>location : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'RedmineRepositoryBrowser'</code><div>
+<ul><li><code>repositoryId : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'SVNWeb'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'ScmManagerSvnRepositoryBrowser'</code><div>
+<ul><li><code>repoUrl : String</code>
+<div><div>
+ Specify the root URL serving this repository (such as <em>https://scm-manager.org/scm/repo/namespace/name</em>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Sventon'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the Sventon repository browser. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be http://somehost.com/svn/
+</div></div>
+
+</li>
+<li><code>repositoryInstance : String</code>
+<div><div>
+ Specify the Sventon repository instance name that references this subversion repository. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be local
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'Sventon2'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the URL of the Sventon repository browser. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be http://somehost.com/svn/
+</div></div>
+
+</li>
+<li><code>repositoryInstance : String</code>
+<div><div>
+ Specify the Sventon repository instance name that references this subversion repository. For example, if you normally browse from http://somehost.com/svn/repobrowser.svn?name=local, this field would be local
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'TeamForge'</code><div>
+<ul><li><code>connectionFactory</code>
+<ul><b>Nested Object</b>
+<li><code>url : String</code>
+<div><div>
+ <p>This should be the URL of your CollabNet TeamForge site. It should be of the form 'https://forge.collab.net'.</p>
+</div></div>
+
+</li>
+<li><code>username : String</code>
+<div><div>
+ <p>The user who will upload the files.</p>
+</div></div>
+
+</li>
+<li><code>password : String</code>
+<div><div>
+ <p>The password for the user specified above. If incorrectly given, the login to the CollabNet TeamForge server will fail.</p>
+</div></div>
+
+</li>
+</ul></li>
+<li><code>project : String</code>
+</li>
+<li><code>repo : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'TracRepositoryBrowser'</code><div>
+<ul></ul></div></li>
+<li><code>$class: 'ViewSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of ViewSVN for this repository (such as <a href="http://svn.apache.org/viewvc" rel="nofollow">this</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'ViewVCRepositoryBrowser'</code><div>
+<ul><li><code>url : String</code>
+</li>
+<li><code>location : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'VisualSVN'</code><div>
+<ul><li><code>url : String</code>
+<div><div>
+ Specify the root URL of VisualSVN for this repository (such as <a href="https://demo-server.visualsvn.com/!/#tortoisesvn" rel="nofollow">https://demo-server.visualsvn.com/!/#tortoisesvn</a>).
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'WebSVN'</code><div>
+<ul><li><code>url : String</code>
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>excludedRegions : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders in this list when determining if a build needs to be triggered. 
+ <p></p> Each exclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	/trunk/myapp/src/main/web/.*\.html
+	/trunk/myapp/src/main/web/.*\.jpeg
+	/trunk/myapp/src/main/web/.*\.gif
+  </pre> The example above illustrates that if only html/jpeg/gif files have been committed to the SCM a build will not occur. 
+ <p></p> More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>excludedUsers : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user. 
+ <p></p>Each exclusion uses literal pattern matching, and must be separated by a new line. 
+ <p></p>
+ <pre>	 auto_build_user
+  </pre> The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.
+</div></div>
+
+</li>
+<li><code>excludedRevprop : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions that are marked with the given revision property (revprop) when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with the correct revprop. 
+ <p></p>This type of exclusion only works with Subversion 1.5 servers and newer. 
+ <p></p>More information on revision properties can be found <a href="http://svnbook.red-bean.com/en/1.5/svn.advanced.props.html" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>excludedCommitMessages : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions with commit messages containing any of the given regular expressions when determining if a build needs to be triggered.
+</div></div>
+
+</li>
+<li><code>includedRegions : String</code>
+<div><div>
+ If set, and Jenkins is set to poll for changes, Jenkins will ignore any files and/or folders that are <b><i>not</i></b> in this list when determining if a build needs to be triggered. 
+ <p></p> Each inclusion uses regular expression pattern matching, and must be separated by a new line. 
+ <p></p> This is useful when you need to check out an entire resource for building, but only want to do the build when a subset has changed. 
+ <p></p>
+ <pre>	/trunk/myapp/c/library1/.*
+	/trunk/myapp/c/library2/.*
+  </pre> If /trunk/myapp is checked out, the build will only occur when there are changes to either the c/library1 and c/library2 subtrees. 
+ <p></p> If there are also excluded regions specified, then a file is not ignored when it is in the included list and <b><i>not</i></b> in the excluded list. 
+ <p></p> More information on regular expressions can be found <a href="http://www.regular-expressions.info/" rel="nofollow">here</a>.
+</div></div>
+
+</li>
+<li><code>ignoreDirPropChanges : boolean</code>
+<div><div>
+ If set, Jenkins ignores svn-property only changes of directories. These changes are ignored when determining whether a build should be triggered and are removed from a build's changeset. Main usage of this property is to ignore svn:mergeinfo changes (which would otherwise e.g. lead to a complete rebuild of a maven project, in spite of incremental build option).
+</div></div>
+
+</li>
+<li><code>filterChangelog : boolean</code>
+<div><div>
+ If set Jenkins will apply the same inclusion and exclusion patterns for displaying changelog entries as it does for polling for changes. If this is disabled, changes which are excluded for polling are still displayed in the changelog.
+</div></div>
+
+</li>
+<li><code>additionalCredentials</code>
+<div><div>
+ <p>If there are additional credentials required in order to obtain a complete checkout of the source, they can be provided here.</p>
+ <p>The <strong>realm</strong> is how the repository self-identifies to a client. It usually has the following format:</p>
+ <p><code>&lt;proto://host:port&gt; Realm Name</code></p>
+ <ul>
+  <li><code>proto</code> is the protocol, e.g. <code>http</code> or <code>svn</code>.</li>
+  <li><code>host</code> is the host how it's accessed by Jenkins, e.g. as IP address <code>192.168.1.100</code>, host name <code>svnserver</code>, or host name and domain <code>svn.example.org</code>.</li>
+  <li><code>port</code> is the port, even if not explicitly specified. By default, this is <code>80</code> for HTTP, <code>443</code> for HTTPS, 3690 for the <code>svn</code> protocol.</li>
+  <li><code>Realm Name</code> is how the repository self-identifies. Common options include <code>VisualSVN Server</code>, <code>Subversion Authentication</code> or the UUID of the repository.</li>
+ </ul>
+ <p>To find out the realm, you could do any of the following:</p>
+ <ul>
+  <li>If you access the repository via HTTP or HTTPS: Open the repo in a web browser without saved credentials. It will use the <code>Realm Name</code> (see above) in the authentication dialog.</li>
+  <li>Use the command line <code>svn</code> program. 
+   <ul>
+    <li>If you don't have stored the credentials, run e.g. <code>svn info https://svnserver/repo</code> and it will tell you the realm when asking you to enter a password, e.g.: <em>Authentication realm: &lt;svn://svnserver:3690&gt; VisualSVN Server</em>.</li>
+    <li>If you have already stored the credentials to access the repository, look for the realm name in one of the files in <code>~/.subversion/auth/svn/simple</code>; it will be two lines below the line <code>svn:realmstring</code>.</li>
+   </ul></li>
+  <li>When accessing a repository via the <code>svn+ssh</code> protocol, the realm has the format <code>username@svn+ssh://host:port</code> – note that the username is <em>before</em> the <code>svn+ssh://</code> (unlike the URL used for normal SVN operations), and that there are no angle brackets and no realm name. For this protocol the default port is 22.</li>
+ </ul>
+ <p>Make sure to enter the realm <em>exactly</em> as shown, starting with a <code>&lt;</code> (except for repositories accessed via <code>svn+ssh</code> – see above).</p>
+</div></div>
+
+<ul><b>Array / List of Nested Object</b>
+<li><code>realm : String</code>
+<div><div>
+ This is the realm that the SvnKit library associates with a specific checkout. For most Subversion servers this will typically be of the format <code>&lt;<i>scheme</i>://<i>hostname</i>(:<i>port</i>)&gt; <i>name</i></code>, while for servers accessed via <code>svn+ssh</code> it is of the format <code>(<i>username</i>@)svn+ssh://<i>hostname</i>(:<i>port</i>)</code>.
+</div></div>
+
+</li>
+<li><code>credentialsId : String</code>
+<div><div>
+ Select the credential from the list of relevant credentials in order to use that credential for checking out the source code.
+</div></div>
+
+</li>
+</ul></li>
+<li><code>quietOperation : boolean</code>
+<div><div>
+ <p>Mimics subversion command line <code>--quiet</code> parameter for <strong>check out / update</strong> operations to help keep the output shorter. Prints nothing, or only summary information.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+<li><code>$class: 'SurroundSCM'</code><div>
+<ul><li><code>server : String</code>
+</li>
+<li><code>serverPort : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+<li><code>repository : String</code>
+</li>
+<li><code>credentialsId : String</code>
+</li>
+<li><code>rsaKey</code> (optional)
+<ul><b>Nested Object</b>
+<li><code>rsaKeyFileId : String</code> (optional)
+</li>
+<li><code>rsaKeyFilePath : String</code> (optional)
+</li>
+<li><code>rsaKeyType</code> (optional)
+<ul><li><b>Values:</b> <code>NoKey</code>, <code>Path</code>, <code>ID</code></li></ul></li>
+<li><code>rsaKeyValue : String</code> (optional)
+</li>
+</ul></li>
+<li><code>rsaKeyFileId : String</code> (optional)
+</li>
+<li><code>rsaKeyFilePath : String</code> (optional)
+<div><div>
+ Enter the full path to the RSA key file for the Surround SCM connection. Example: C:\SurroundRSAKeyFile.xml
+</div></div>
+
+</li>
+<li><code>rsaKeyPath : String</code> (optional)
+</li>
+</ul></div></li>
+<li><code>$class: 'SynergySCM'</code><div>
+<ul><li><code>project : String</code>
+</li>
+<li><code>database : String</code>
+</li>
+<li><code>release : String</code>
+</li>
+<li><code>purpose : String</code>
+</li>
+<li><code>username : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>engine : String</code>
+</li>
+<li><code>oldProject : String</code>
+</li>
+<li><code>baseline : String</code>
+</li>
+<li><code>oldBaseline : String</code>
+</li>
+<li><code>ccmHome : String</code>
+</li>
+<li><code>remoteClient : boolean</code>
+</li>
+<li><code>detectConflict : boolean</code>
+</li>
+<li><code>replaceSubprojects : boolean</code>
+</li>
+<li><code>checkForUpdateWarnings : boolean</code>
+</li>
+<li><code>leaveSessionOpen : boolean</code>
+</li>
+<li><code>maintainWorkarea : boolean</code>
+</li>
+<li><code>checkTaskModifiedObjects : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'VaultSCM'</code><div>
+<ul><li><code>serverName : String</code>
+<div><div>
+ Specify the hostname or IP address of the vault server.
+</div></div>
+
+</li>
+<li><code>path : String</code>
+</li>
+<li><code>userName : String</code>
+</li>
+<li><code>password : String</code>
+</li>
+<li><code>repositoryName : String</code>
+</li>
+<li><code>vaultName : String</code>
+</li>
+<li><code>sslEnabled : boolean</code>
+</li>
+<li><code>useNonWorkingFolder : boolean</code>
+</li>
+<li><code>merge : String</code>
+</li>
+<li><code>fileTime : String</code>
+</li>
+<li><code>makeWritableEnabled : boolean</code>
+</li>
+<li><code>verboseEnabled : boolean</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'hudson.plugins.gradle_repo.RepoScm'</code><div>
+<ul><li><code>repositoryUrl : String</code>
+</li>
+<li><code>branch : String</code>
+</li>
+</ul></div></li>
+<li><code>$class: 'hudson.plugins.repo.RepoScm'</code><div>
+<div><div>
+ <p>The <a href="https://plugins.jenkins.io/repo/" rel="nofollow">repo plugin</a> provides <a href="https://gerrit.googlesource.com/git-repo" rel="nofollow">Repo</a> as an SCM tools in Jenkins.</p>
+ <p>The repo plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step" rel="nofollow"><code>checkout</code></a> step. The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator" rel="nofollow"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select repo plugin checkout options and provides online help for each of the options.</p>
+</div></div>
+<ul><li><code>manifestRepositoryUrl : String</code>
+<div><div>
+ <p>The URL of the manifest. This is passed to repo as <code>repo init -u <i>url</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>cleanFirst : boolean</code> (optional)
+<div><div>
+ <p>When this is checked the first thing to do will be a</p>
+ <pre>repo forall -c "git clean -fdx"</pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>currentBranch : boolean</code> (optional)
+<div><div>
+ <p>Fetch only the current branch from server. Increases the speed of the repo sync operation. This is passed to repo as <code>repo init <i>--current-branch</i></code> and <code>repo sync <i>-c</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>depth : int</code> (optional)
+<div><div>
+ <p>Specify the depth in history to sync from the source. The default is to sync all of the history. Use 1 to just sync the most recent commit. This is passed to repo as <code>repo init --depth=<i>n</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>destinationDir : String</code> (optional)
+<div><div>
+ <p>The sub-directory of the workspace where the source should be synced. The default is the root of the workspace.</p>
+</div></div>
+
+</li>
+<li><code>extraEnvVars</code> (optional)
+<ul><li><b>Type:</b> <code>java.util.Map&lt;java.lang.String, java.lang.String&gt;</code></li>
+</ul></li>
+<li><code>fetchSubmodules : boolean</code> (optional)
+<div><div>
+ <p>Fetch submodules for from server. This is passed to repo as <code>repo sync <i>--fetch-submodules</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>forceSync : boolean</code> (optional)
+<div><div>
+ <p>Overwrite an existing git directory if it needs to point to a different object directory. WARNING: this may cause loss of data. This is passed to repo as <code>repo sync <i>--force-sync</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>ignoreProjects : String</code> (optional)
+</li>
+<li><code>jobs : int</code> (optional)
+<div><div>
+ <p>Specify the number of projects to fetch simultaneously. The default is 1. This is passed to repo as <code>repo sync --jobs=<i>n</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>localManifest : String</code> (optional)
+<div><div>
+ <p>The contents of <code>.repo/local_manifests/local.xml</code>. This is written prior to calling sync. The default is to not use a <code>local.xml</code> file.</p>
+ <p>The contents may be given here literally, as XML; see the example below. Such literal content <b>must</b> start with the string <code>&lt;?xml</code>. Alternatively, the content may be given as an URL, in which case the file pointed by the URL is used. If the content does not start with the <code>&lt;?xml</code> prefix, it is assumed to be an URL.</p>
+ <p><b>An example</b></p>
+ <pre>    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    &lt;manifest&gt;
+      &lt;project path="external/project" name="org/project" remote="github" revision="master" /&gt;
+    &lt;/manifest&gt;
+  </pre>
+</div></div>
+
+</li>
+<li><code>manifestBranch : String</code> (optional)
+<div><div>
+ <p>The branch of the manifest to use. This is passed to repo as <code>repo init -b <i>branchname</i></code>. Repo will default to <i>master</i> if a branch name isn't provided.</p>
+</div></div>
+
+</li>
+<li><code>manifestFile : String</code> (optional)
+<div><div>
+ <p>The initial manifest file to use while initializing the repo. This is passed to repo as <code>repo init -m <i>manifestFile</i></code>. If a manifest file is not specified, repo uses the default of "default.xml".</p>
+</div></div>
+
+</li>
+<li><code>manifestGroup : String</code> (optional)
+<div><div>
+ <p>Restricts manifest projects to ones tagged with provided group name. This is passed to repo as <code>repo init -g <i>groupName</i></code>. If a group name is not provided, the <code>-g</code> option is not passed to repo and it will default to fetching projects that are tagged with 'default'.</p>
+</div></div>
+
+</li>
+<li><code>manifestPlatform : String</code> (optional)
+<div><div>
+ <p>Restrict manifest projects to ones with a specified platform group <code>[auto|all|none|linux|darwin|...]</code> This is passed to repo as <code>repo init -P <i>platformName</i></code>. If a platform is not provided, the <code>-p</code> option is not passed to repo and it will default to <code>auto</code> and ony fetch projects which needed for current system.</p>
+</div></div>
+
+</li>
+<li><code>manifestSubmodules : boolean</code> (optional)
+<div><div>
+ <p>Sync any submodules associated with the manifest repo. This is passed to repo as <code>repo init <i>--submodules</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>mirrorDir : String</code> (optional)
+<div><div>
+ <p>The location of the mirror directory to reference when initialising the repository. This is passed to repo as <code>repo sync --reference=<i>DIR</i></code>. This speeds up fetching code and isn't used by default.</p>
+</div></div>
+
+</li>
+<li><code>noCloneBundle : boolean</code> (optional)
+<div><div>
+ <p>When this is checked <code>--no-clone-bundle</code> is used when running the <code>repo init</code> and <code>repo sync</code> commands.</p>
+</div></div>
+
+</li>
+<li><code>noTags : boolean</code> (optional)
+<div><div>
+ <p>Don't fetch tags. This is passed to repo as <code>repo init <i>--no-tags</i></code> and <code>repo sync <i>--no-tags</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>quiet : boolean</code> (optional)
+<div><div>
+ <p>Make repo more quiet. This is passed to repo as <code>repo sync <i>-q</i></code>.</p>
+</div></div>
+
+</li>
+<li><code>repoBranch : String</code> (optional)
+<div><div>
+ <p>Use a specific branch for pulling repo itself. By default this is empty, and repo will be using its default branch (i.e. stable)</p>
+</div></div>
+
+</li>
+<li><code>repoUrl : String</code> (optional)
+<div><div>
+ <p>Pull repo itself from this git repository. By default this is empty, and repo will be pulled from its default git url (i.e. googles)</p>
+</div></div>
+
+</li>
+<li><code>resetFirst : boolean</code> (optional)
+<div><div>
+ <p>When this is checked the first thing to do will be a</p>
+ <pre>repo forall -c "git reset --hard"</pre>
+ <p></p>
+</div></div>
+
+</li>
+<li><code>showAllChanges : boolean</code> (optional)
+<div><div>
+ <p>When this is checked <code>--first-parent</code> is no longer passed to <code>git log</code> when determining changesets.</p>
+</div></div>
+
+</li>
+<li><code>trace : boolean</code> (optional)
+<div><div>
+ <p>Trace git command execution. This is passed to repo as <code>repo <i>--trace</i> &lt;subcommand&gt;</code>.</p>
+</div></div>
+
+</li>
+<li><code>worktree : boolean</code> (optional)
+<div><div>
+ <p>Use `git worktree` for checkouts (At least, Git version 2.15 is required to avoid dangerous gc bugs). Usefull under Windows because it no longer require symlinks at all.</p>
+</div></div>
+
+</li>
+</ul></div></li>
+</ul></li>
+<li><code>changelog : boolean</code> (optional)
+<div><div>
+ Enable or Disable 'Include in changelog': 
+ <p>If 'Include in changelog' is enabled for an SCM source, then when a build occurs, the changes from that SCM source will be included in the changelog.</p>
+ <p>If 'Include in changelog' is disabled, then when a build occurs, the changes from this SCM source will not be included in the changelog.</p>
+</div></div>
+
+</li>
+<li><code>poll : boolean</code> (optional)
+<div><div>
+ Enable or Disable 'Include in polling' 
+ <p>If 'Include in polling' is enabled or 'Include in changelog' is enabled, then when polling occurs, the job will be started if changes are detected from this SCM source.</p>
+ <p>If 'Include in polling' is disabled and 'Include in changelog' is disabled, then when polling occurs, changes that are detected from this repository will be ignored.</p>
+</div></div>
+
+</li>
+</ul>
+
+
+++++


### PR DESCRIPTION
Addresses the problem associated with #203 
Added a line to create the new folder in `allAscii.zip`. Rest everything remains the same.

@MarkEWaite kindly review this and let me know if it gets a green flag. I'll also test the `allAscii.zip` generated from this build against the make script of `jenkins.io`.