### PR TITLE
remove target from replacing link

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
@@ -51,8 +51,8 @@ public class ProcessAsciiDoc {
             while ((line = br.readLine()) != null) {
                 if (!flag && line.contains("<li><code>" + className + "</code><div>")) {
                     flag = true;
-                    duplicate.append("<li><span><a href=\"/doc/pipeline/steps/params/" + url
-                            + "\" target=\"_blank\"><code>" + className + "</code></a></span></li>\n");
+                    duplicate.append("<li><span><a href=\"/doc/pipeline/steps/params/" + url + "\"><code>" + className
+                            + "</code></a></span></li>\n");
                 } else if (!flag) {
                     duplicate.append(line).append("\n");
                 }

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
@@ -69,7 +69,7 @@ public class ProcessAsciiDocTest {
                 }
             }
             assertEquals(
-                    "<li><span><a href=\"/doc/pipeline/steps/params/gitscm\" target=\"_blank\"><code>$class: 'GitSCM'</code></a></span></li>",
+                    "<li><span><a href=\"/doc/pipeline/steps/params/gitscm\"><code>$class: 'GitSCM'</code></a></span></li>",
                     link);
         } catch (RuntimeException | IOException ex) {
             assertTrue(false);


### PR DESCRIPTION
So that clicking link does not force a new tab to be opened.

cc: @MarkEWaite 