### PR TITLE
chore(pipeline) use the agent ZIP command line instead of pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,8 @@ pipeline {
         stage('Clean up') {
             steps {
                 dir('docFolder') {
-                    zip dir: './allAscii', glob: '', zipFile: 'allAscii.zip'
-                    zip dir: './declarative', glob: '', zipFile: 'declarative.zip'
+                    sh 'zip -r allAscii.zip ./allAscii'
+                    sh 'zip -r declarative.zip ./declarative'
                     archiveArtifacts artifacts: 'allAscii.zip,declarative.zip', fingerprint: true
                 }
             }


### PR DESCRIPTION
Rationale: no need to ZIP files on the controller when an agent can do it for us.