### PR TITLE
Match previous zip file content layout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,11 @@ pipeline {
         stage('Clean up') {
             steps {
                 dir('docFolder') {
-                    sh 'zip -r allAscii.zip ./allAscii'
-                    sh 'zip -r declarative.zip ./declarative'
+                    // allAscii and declarative must not include directory name in their zip files
+                    sh  '''
+                        ( cd allAscii    && zip -r -1 -q ../allAscii.zip    . )
+                        ( cd declarative && zip -r -1 -q ../declarative.zip . )
+                        '''
                     archiveArtifacts artifacts: 'allAscii.zip,declarative.zip', fingerprint: true
                 }
             }


### PR DESCRIPTION
Previously the zip file content was

```
M Filemode      Length  Date         Time      File
- ----------  --------  -----------  --------  ---------------
  -rw-rw-r--      4519  27-Oct-2022  08:37:24  agent.adoc
  -rw-rw-r--    469284  27-Oct-2022  08:37:28  options.adoc
  -rw-rw-r--     53838  27-Oct-2022  08:37:30  parameters.adoc
  -rw-rw-r--     68082  27-Oct-2022  08:37:30  triggers.adoc
  -rw-rw-r--     11761  27-Oct-2022  08:37:32  when.adoc
- ----------  --------  -----------  --------  ---------------
                607484                         5 files
```

The switch from internal to command line zip resulted in a new layout that includes the directory name:

```
M Filemode      Length  Date         Time      File
- ----------  --------  -----------  --------  ---------------------------
  drwxrwxr-x         0  31-Oct-2022  20:56:32  declarative/
  -rw-rw-r--     52468  31-Oct-2022  20:56:30  declarative/parameters.adoc
  -rw-rw-r--     11761  31-Oct-2022  20:56:32  declarative/when.adoc
  -rw-rw-r--    467989  31-Oct-2022  20:56:28  declarative/options.adoc
  -rw-rw-r--     68082  31-Oct-2022  20:56:30  declarative/triggers.adoc
  -rw-rw-r--      4519  31-Oct-2022  20:56:22  declarative/agent.adoc
- ----------  --------  -----------  --------  ---------------------------
                604819                         6 files
```

After this change, the content will look like:

```
M Filemode      Length  Date         Time      File
- ----------  --------  -----------  --------  ---------------
  -rw-rw-r--    469284  27-Oct-2022  08:37:28  options.adoc
  -rw-rw-r--      4519  27-Oct-2022  08:37:24  agent.adoc
  -rw-rw-r--     53838  27-Oct-2022  08:37:30  parameters.adoc
  -rw-rw-r--     11761  27-Oct-2022  08:37:32  when.adoc
  -rw-rw-r--     68082  27-Oct-2022  08:37:30  triggers.adoc
- ----------  --------  -----------  --------  ---------------
                607484                         5 files
```