### PR TITLE
Deduplicate scmGit same as GitSCM was deduplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ The parameters that need to be separated to new pages can be entered in `config.
 
 * Ensure that a specified parameter's documentation is the same everywhere it occurs in the Pipeline Steps Reference. For example, `perforce` contains different documentation under the checkout step's scm parameter and the scanForIssues step's tool parameter. Hence, it can not be included in the configuration file.
 
-* Maintain the order of the parameters such that if one parameter occurs inside the nesting of another, it is written above the other in the configuration file. For example, `$class: 'GitSCM'` is present inside `$class: MultiSCM` in checkout step, hence, it must be written above in the configuration file.
+* Maintain the order of the parameters such that if one parameter occurs inside the nesting of another, it is written above the other in the configuration file. For example, `scmGit` is present inside `$class: MultiSCM` in checkout step, hence, it must be written above in the configuration file.
 
 * A parameter must have at least 100 lines of asciidoc code present in the location from which it is supposed to be removed.

--- a/config.txt
+++ b/config.txt
@@ -5,6 +5,7 @@
 $class: 'CCUCMScm'
 $class: 'CVSSCM'
 $class: 'CvsProjectset'
+scmGit
 $class: 'GitSCM'
 $class: 'MercurialSCM'
 $class: 'RTCScm'


### PR DESCRIPTION
## Deduplicate scmGit same as GitSCM was deduplicated

[Git plugin 5.0.0](https://github.com/jenkinsci/git-plugin/releases/tag/git-5.0.0) added symbols in order to simplify Pipeline editing and reading.  Instead of `$class: 'GitSCM'`, the symbol `scmGit` is used. Instead of `$class: 'SubmoduleOption'`, the symbol `submodule` is used. 

The symbol improvement is nice for users and makes the documentation easier to read, but it needs to be matched with a change in the Pipeline steps doc generator.  Without this change, the `scmGit` documentation is duplicated in many different locations in the Pipeline steps reference.  As an example, the [`multiscm` step](https://www.jenkins.io/doc/pipeline/steps/params/multiscm/) previously had a link to a single page for `GitSCM` documentation.  Now, it embeds the `scmGit` documentation inside the page (multiple times), duplicating the same content that exists in several other locations.  That slows the page loading and worsens the reading experience.

[WEBSITE-809](https://issues.jenkins.io/browse/WEBSITE-809) lists pages that were improved by the Pipeline steps doc generator improvement project.  Some examples from its list that will be improved by this change are:

* [Pipeline: Multibranch](https://www.jenkins.io/doc/pipeline/steps/workflow-multibranch/)
* [Pipeline: Groovy Libraries](https://www.jenkins.io/doc/pipeline/steps/pipeline-groovy-lib/)

One of the key improvements for page load time and user experience with the Pipeline steps documentation improvement project was the deduplication of content.  We need this change to bring back that deduplication for the git plugin documentation.

@vihaanthora or @jmMeessen I'd love to have your review of the proposed change.