### PR TITLE
fix(agent): move to not bigmem agent as it had been deprecated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     // This build requires at least 8Gb of memory
-    agent { label 'linux-amd64-big' }
+    agent { label 'linux-amd64' }
     triggers {
         cron('H H * * 0')
     }


### PR DESCRIPTION
build work with agent label linux-amd64 and as we have discarded the bigmem ones, it need to change of agents