### PR TITLE
Revert "Bump jenkins from 1.97 to 1.98 (#289)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.98</version>
+    <version>1.97</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins.io/issues/63551

Not clear to me why the update from 1.97 to 1.98 caused the documentation
to not be generated correctly.  More research is needed, but it is
valuable to restore the documentation content quickly, then investigate
more carefully.

This reverts commit dc6d2de1ab54eb89ef3bc43cd7a6898cf3d521c8.
