### PR TITLE
Avoid exception due to small gitblit docs

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -28,7 +28,6 @@ $class: 'RunSelectorParameter'
 $class: 'BacklogPullRequestSCMSource'
 multiBranch
 dagshubScmSource
-gitblit
 git
 $class: 'GiteaSCMSource'
 multiGraph


### PR DESCRIPTION
Documentation builds successfully, but we should not need to have an invalid configuration entry in the config.txt file.
