### PR TITLE
Replace apache commons io with standard java calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
       <version>2.33</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
@@ -12,7 +12,6 @@ import hudson.triggers.TriggerDescriptor;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -62,7 +61,8 @@ public class DeclarativeSteps {
             String whole9yards = ToAsciiDoc.generateDirectiveHelp(entry.getKey(), pluginDescMap, true);
 
             try {
-                Files.writeString(new File(declPath, entry.getKey() + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
+                Files.writeString(
+                        new File(declPath, entry.getKey() + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
             } catch (Exception ex) {
                 LOG.log(Level.SEVERE, "Error generating directive file for " + entry.getKey() + ".  Skip.", ex);
                 // continue to next directive

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
@@ -11,6 +11,8 @@ import hudson.model.ParameterDefinition;
 import hudson.triggers.TriggerDescriptor;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -20,7 +22,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.FileUtils;
 import org.jenkinsci.infra.tools.HyperLocalPluginManager;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
@@ -61,8 +62,7 @@ public class DeclarativeSteps {
             String whole9yards = ToAsciiDoc.generateDirectiveHelp(entry.getKey(), pluginDescMap, true);
 
             try {
-                FileUtils.writeStringToFile(
-                        new File(declPath, entry.getKey() + ".adoc"), whole9yards, StandardCharsets.UTF_8);
+                Files.writeString(new File(declPath, entry.getKey() + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
             } catch (Exception ex) {
                 LOG.log(Level.SEVERE, "Error generating directive file for " + entry.getKey() + ".  Skip.", ex);
                 // continue to next directive

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -16,10 +16,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -248,7 +246,12 @@ public class PipelineStepExtractor {
 
         JSONObject deprecatedPlugins = new JSONObject();
         try {
-            deprecatedPlugins = new JSONObject(new String(new URL("https://updates.jenkins.io/current/update-center.actual.json").openStream().readAllBytes(), StandardCharsets.UTF_8)).getJSONObject("deprecations");
+            deprecatedPlugins = new JSONObject(new String(
+                            new URL("https://updates.jenkins.io/current/update-center.actual.json")
+                                    .openStream()
+                                    .readAllBytes(),
+                            StandardCharsets.UTF_8))
+                    .getJSONObject("deprecations");
 
         } catch (IOException ex) {
             LOG.log(Level.WARNING, "Update center could not be read" + ex);
@@ -266,7 +269,7 @@ public class PipelineStepExtractor {
 
             try {
                 Files.writeString(
-                    new File(allAsciiPath, plugin + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
+                        new File(allAsciiPath, plugin + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
             } catch (Exception ex) {
                 LOG.log(Level.SEVERE, "Error generating plugin file for " + plugin + ".  Skip.", ex);
                 // continue to next plugin

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -18,6 +18,8 @@ import java.io.Serializable;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -30,8 +32,6 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 import jenkins.InitReactorRunner;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jenkinsci.infra.tools.HyperLocalPluginManager;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableParameter;
@@ -248,10 +248,8 @@ public class PipelineStepExtractor {
 
         JSONObject deprecatedPlugins = new JSONObject();
         try {
-            deprecatedPlugins = new JSONObject(IOUtils.toString(
-                            new URL("https://updates.jenkins.io/current/update-center.actual.json"),
-                            Charset.forName("UTF-8")))
-                    .getJSONObject("deprecations");
+            deprecatedPlugins = JSONObject deprecatedPlugins = new JSONObject(new String(new URL("https://updates.jenkins.io/current/update-center.actual.json").openStream().readAllBytes(), StandardCharsets.UTF_8)).getJSONObject("deprecations");
+
         } catch (IOException ex) {
             LOG.log(Level.WARNING, "Update center could not be read" + ex);
         }
@@ -267,8 +265,8 @@ public class PipelineStepExtractor {
             String whole9yards = ToAsciiDoc.generatePluginHelp(plugin, displayName, byPlugin, isDeprecated, true);
 
             try {
-                FileUtils.writeStringToFile(
-                        new File(allAsciiPath, plugin + ".adoc"), whole9yards, StandardCharsets.UTF_8);
+                Files.writeString(
+                    new File(allAsciiPath, plugin + ".adoc").toPath(), whole9yards, StandardCharsets.UTF_8);
             } catch (Exception ex) {
                 LOG.log(Level.SEVERE, "Error generating plugin file for " + plugin + ".  Skip.", ex);
                 // continue to next plugin

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -248,7 +248,7 @@ public class PipelineStepExtractor {
 
         JSONObject deprecatedPlugins = new JSONObject();
         try {
-            deprecatedPlugins = JSONObject deprecatedPlugins = new JSONObject(new String(new URL("https://updates.jenkins.io/current/update-center.actual.json").openStream().readAllBytes(), StandardCharsets.UTF_8)).getJSONObject("deprecations");
+            deprecatedPlugins = new JSONObject(new String(new URL("https://updates.jenkins.io/current/update-center.actual.json").openStream().readAllBytes(), StandardCharsets.UTF_8)).getJSONObject("deprecations");
 
         } catch (IOException ex) {
             LOG.log(Level.WARNING, "Update center could not be read" + ex);

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.logging.Logger;
-import org.apache.commons.io.FilenameUtils;
 
 /**
  * Acts as a processing layer after the AsciiDocs are generated from
@@ -109,7 +108,8 @@ public class ProcessAsciiDoc {
                 LOG.info("Iterating through parameter class name: " + className);
                 if (directoryListing != null) {
                     for (File child : directoryListing) {
-                        String type = FilenameUtils.getExtension(child.getName());
+                        String fileName = child.getName();
+                        String type = fileName.substring(fileName.lastIndexOf('.') + 1);
                         if (type.equals("adoc")) {
                             Path currentPath = Path.of(child.getPath());
                             Files.writeString(currentPath, separateClass(className, allAscii, child, linesThreshold));

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -273,7 +273,7 @@ public class ToAsciiDoc {
         for (Klass<?> c = Klass.java(type); c != null; c = c.getSuperClass()) {
             URL u = c.getResource(name);
             if (u != null) {
-                return new String(Files.readAllBytes(Paths.get(url.toURI())), StandardCharsets.UTF_8);
+                return new String(Files.readAllBytes(Paths.get(u.toURI())), StandardCharsets.UTF_8);
             }
         }
         return null;

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -3,11 +3,12 @@ package org.jenkinsci.pipeline_steps_doc_generator;
 import hudson.Main;
 import hudson.model.Descriptor;
 import java.io.IOException;
-import java.lang.String;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,12 +118,13 @@ public class ToAsciiDoc {
     }
 
     private static String describeErrorType(ParameterType type) {
-        return type.getActualType().toString()
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\"", "&quot;")
-            .replace("'", "&#39;");
+        return type.getActualType()
+                .toString()
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 
     private static String generateAttrHelp(DescribableParameter param) throws Exception {
@@ -273,7 +275,13 @@ public class ToAsciiDoc {
         for (Klass<?> c = Klass.java(type); c != null; c = c.getSuperClass()) {
             URL u = c.getResource(name);
             if (u != null) {
-                return new String(Files.readAllBytes(Paths.get(u.toURI())), StandardCharsets.UTF_8);
+                URI uri;
+                try {
+                    uri = u.toURI();
+                } catch (URISyntaxException ue) {
+                    throw new IOException(ue);
+                }
+                return new String(Files.readAllBytes(Paths.get(uri)), StandardCharsets.UTF_8);
             }
         }
         return null;

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -3,6 +3,10 @@ package org.jenkinsci.pipeline_steps_doc_generator;
 import hudson.Main;
 import hudson.model.Descriptor;
 import java.io.IOException;
+import java.lang.String;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,8 +19,6 @@ import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.structs.describable.ArrayType;
 import org.jenkinsci.plugins.structs.describable.AtomicType;
@@ -115,7 +117,12 @@ public class ToAsciiDoc {
     }
 
     private static String describeErrorType(ParameterType type) {
-        return StringEscapeUtils.escapeHtml(type.getActualType().toString());
+        return type.getActualType().toString()
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;");
     }
 
     private static String generateAttrHelp(DescribableParameter param) throws Exception {
@@ -266,7 +273,7 @@ public class ToAsciiDoc {
         for (Klass<?> c = Klass.java(type); c != null; c = c.getSuperClass()) {
             URL u = c.getResource(name);
             if (u != null) {
-                return IOUtils.toString(u, "UTF-8");
+                return new String(Files.readAllBytes(Paths.get(url.toURI())), StandardCharsets.UTF_8);
             }
         }
         return null;


### PR DESCRIPTION
#316 Replaced Apache Commons io library calls with Java Standard 11 runtime libraries. 

Made changes in following files:

- [x] - src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
- [x] - src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
- [x] - src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
- [x] - src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java

Not sure about replacement of StringEscapeUtils.