### PR TITLE
Fix reading help.html files from plugin zip trees

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDoc.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,7 +35,7 @@ public class ProcessAsciiDoc {
      */
     public String separateClass(String className, String allAscii, File child, int linesThreshold)
             throws IOException, RuntimeException {
-        BufferedReader br = new BufferedReader(new FileReader(child));
+        BufferedReader br = new BufferedReader(new FileReader(child, StandardCharsets.UTF_8));
         StringBuilder duplicate = new StringBuilder(); // contains the content of the current file minus the parameter
         // details
         String line;

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.pipeline_steps_doc_generator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Main;
 import hudson.model.Descriptor;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -271,17 +269,14 @@ public class ToAsciiDoc {
      * @return file content
      * @throws IOException if file can't be read
      */
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "URL comes from a safe source")
     static String getHelp(String name, Class<?> type) throws IOException {
         for (Klass<?> c = Klass.java(type); c != null; c = c.getSuperClass()) {
             URL u = c.getResource(name);
             if (u != null) {
-                URI uri;
-                try {
-                    uri = u.toURI();
-                } catch (URISyntaxException ue) {
-                    throw new IOException(ue);
+                try (BufferedReader br = new BufferedReader(new InputStreamReader(u.openStream()))) {
+                    return br.lines().collect(Collectors.joining("\n"));
                 }
-                return new String(Files.readAllBytes(Paths.get(uri)), StandardCharsets.UTF_8);
             }
         }
         return null;

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ProcessAsciiDocTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.io.FileMatchers.aReadableFile;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -44,7 +43,7 @@ public class ProcessAsciiDocTest {
     }
 
     private String readFile(String fileName) throws Exception {
-        return new String(Files.readAllBytes(Paths.get(fileName)), StandardCharsets.UTF_8);
+        return Files.readString(Paths.get(fileName)).replace("\r", "").trim();
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciidocTest.java
+++ b/src/test/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciidocTest.java
@@ -1,8 +1,20 @@
 package org.jenkinsci.pipeline_steps_doc_generator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.Test;
 
@@ -18,6 +30,39 @@ public class ToAsciidocTest {
                     desc.trim());
         } catch (Exception e) {
             fail("Cannot describe map " + e);
+        }
+    }
+
+    @Test
+    public void getHelpWithNoStaplerConstructor() throws IOException {
+        PipelineStepExtractor pes = new PipelineStepExtractor();
+        Path plugins = setupPluginDir(pes);
+        downloadCpsPlugin(plugins);
+        Map<String, Map<String, List<QuasiDescriptor>>> steps = pes.findSteps();
+        QuasiDescriptor parallel = steps.get("workflow-cps").get("Steps").stream()
+                .filter(desc -> desc.getSymbol().equals("parallel"))
+                .findFirst()
+                .orElseThrow();
+        String desc = ToAsciiDoc.generateStepHelp(parallel);
+        assertThat(desc, containsString("parallel firstBranch"));
+        assertThat(desc, not(containsString("Exception")));
+    }
+
+    private Path setupPluginDir(PipelineStepExtractor pes) throws IOException {
+        Path tempDir = Files.createTempDirectory("plugins");
+        pes.homeDir = tempDir.toFile().getAbsolutePath();
+        Path plugins = tempDir.resolve("plugins");
+        Files.createDirectory(plugins);
+        return plugins;
+    }
+
+    private void downloadCpsPlugin(Path plugins) throws IOException {
+        URL website = new URL(
+                "https://updates.jenkins.io/download/plugins/workflow-cps/3697.vb_470e454c232/workflow-cps.hpi");
+        ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+        try (FileOutputStream fos =
+                new FileOutputStream(plugins.resolve("workflow-cps.hpi").toFile())) {
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins.io/issues/6550 (at least the test that replicates the issue is now green locally).