### PR TITLE
Use Java 21, not Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                             url:'https://github.com/jenkinsci/backend-extension-indexer.git',
                         branch: 'master'
                     script {
-                        infra.runMaven(['clean', 'install', '-DskipTests'], 11)
+                        infra.runMaven(['clean', 'install', '-DskipTests'], 21)
                     }
                     sh 'java -XshowSettings:vm -jar ./target/*-bin/extension-indexer*.jar -plugins ./plugins && mv plugins ..'
                 }
@@ -43,7 +43,7 @@ pipeline {
                 dir('docFolder') {
                     checkout scm
                     script {
-                        infra.runMaven(['clean', 'install', '-DskipTests'], 11)
+                        infra.runMaven(['clean', 'install', '-DskipTests'], 21)
                     }
                     sh 'mv ../plugins . && java -XshowSettings:vm -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
                 }


### PR DESCRIPTION
## Use Java 21, not Java 11

June 18, 2024 Jenkins weekly will require Java 17 or newer.  Java 21 has been supported by the Jenkins project for a long team.

## Testing done

Compared output from the build of this pull request with the output from the master branch and the content is the same.