### PR TITLE
Generate Java 17 byte code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,9 +31,11 @@ pipeline {
                             url:'https://github.com/jenkinsci/backend-extension-indexer.git',
                         branch: 'master'
                     script {
-                        infra.runMaven(['clean', 'install', '-DskipTests'], 21)
+                        infra.runMaven(['clean', 'install', '-DskipTests'], 17)
                     }
-                    sh 'java -XshowSettings:vm -jar ./target/*-bin/extension-indexer*.jar -plugins ./plugins && mv plugins ..'
+		    withEnv(['JAVA_HOME=/opt/jdk-17','PATH+JDK21=/opt/jdk-17/bin']) {
+			sh 'java -XshowSettings:vm -jar ./target/*-bin/extension-indexer*.jar -plugins ./plugins && mv plugins ..'
+		    }
                 }
             }
         }
@@ -43,9 +45,11 @@ pipeline {
                 dir('docFolder') {
                     checkout scm
                     script {
-                        infra.runMaven(['clean', 'install', '-DskipTests'], 21)
+                        infra.runMaven(['clean', 'install', '-DskipTests'], 17)
                     }
-                    sh 'mv ../plugins . && java -XshowSettings:vm -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
+		    withEnv(['JAVA_HOME=/opt/jdk-17','PATH+JDK21=/opt/jdk-17/bin']) {
+                        sh 'mv ../plugins . && java -XshowSettings:vm -jar ./target/*-bin/pipeline-steps-doc-generator*.jar'
+		    }
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkins-infra/${project.artifactId}</gitHubRepo>
+    <maven.compiler.release>17</maven.compiler.release>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 


### PR DESCRIPTION
Other builds are failing because the Jenkins infra task fails.  Assumed that is because the Java 17 agent is not available yet on the infra machine.