### PR TITLE
Use Java 17 features to simplify the code

### DIFF
--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/DeclarativeSteps.java
@@ -123,8 +123,7 @@ public class DeclarativeSteps {
         Map<Class<? extends Descriptor>, Predicate<Descriptor>> filters = new HashMap<>();
 
         filters.put(StepDescriptor.class, d -> {
-            if (d instanceof StepDescriptor) {
-                StepDescriptor s = (StepDescriptor) d;
+            if (d instanceof StepDescriptor s) {
                 // Note that this is lifted from org.jenkinsci.plugins.pipeline.modeldefinition.model.Options, with the
                 // blocked steps hardcoded. This could be better.
                 return s.takesImplicitBlockArgument()

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/PipelineStepExtractor.java
@@ -158,7 +158,7 @@ public class PipelineStepExtractor {
     }
 
     protected static Stream<Descriptor<?>> getMetaDelegates(Descriptor<?> d) {
-        if (d instanceof StepDescriptor && ((StepDescriptor) d).isMetaStep()) {
+        if (d instanceof StepDescriptor descriptor && descriptor.isMetaStep()) {
             DescribableModel<?> m = DescribableModel.of(d.clazz);
             Collection<DescribableParameter> parameters = m.getParameters();
             if (parameters.size() == 1) {

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/QuasiDescriptor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/QuasiDescriptor.java
@@ -27,7 +27,7 @@ public class QuasiDescriptor {
             if (!symbolValues.isEmpty()) {
                 return symbolValues.iterator().next();
             } else if (parent != null) {
-                return String.format("%s([$class: '%s'])", parent.getFunctionName(), real.clazz.getSimpleName());
+                return "%s([$class: '%s'])".formatted(parent.getFunctionName(), real.clazz.getSimpleName());
             } else {
                 throw new AssertionError("Symbol present but no values defined.");
             }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/QuasiDescriptor.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/QuasiDescriptor.java
@@ -20,8 +20,8 @@ public class QuasiDescriptor {
     }
 
     public String getSymbol() {
-        if (real instanceof StepDescriptor) {
-            return ((StepDescriptor) real).getFunctionName();
+        if (real instanceof StepDescriptor descriptor) {
+            return descriptor.getFunctionName();
         } else {
             Set<String> symbolValues = SymbolLookup.getSymbolValue(real);
             if (!symbolValues.isEmpty()) {

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -63,30 +63,30 @@ public class ToAsciiDoc {
 
     static String describeType(ParameterType type, String prefix) throws Exception {
         StringBuilder typeInfo = new StringBuilder();
-        if (type instanceof EnumType) {
+        if (type instanceof EnumType enumType) {
             typeInfo.append("<li><b>")
                     .append(prefix)
                     .append("Values:</b> ")
-                    .append(Arrays.stream((((EnumType) type).getValues()))
+                    .append(Arrays.stream((enumType.getValues()))
                             .map(v -> "<code>" + v + "</code>")
                             .collect(Collectors.joining(", ")))
                     .append("</li>");
-        } else if (type instanceof ArrayType) {
-            type = ((ArrayType) type).getElementType();
+        } else if (type instanceof ArrayType arrayType) {
+            type = arrayType.getElementType();
             if (!(type instanceof AtomicType)) {
                 typeInfo.append(describeType(type, ARRAY_LIST_OF + prefix));
             }
-        } else if (type instanceof HomogeneousObjectType) {
+        } else if (type instanceof HomogeneousObjectType objectType) {
             typeInfo.append("<b>")
                     .append(prefix)
                     .append("Nested Object</b>\n")
                     // TODO may need to note a symbol if present
-                    .append(generateHelp(((HomogeneousObjectType) type).getSchemaType(), false));
-        } else if (type instanceof HeterogeneousObjectType) {
+                    .append(generateHelp(objectType.getSchemaType(), false));
+        } else if (type instanceof HeterogeneousObjectType objectType) {
             typeInfo.append("<b>").append(prefix).append("Nested Choice of Objects</b>\n");
-            if (((HeterogeneousObjectType) type).getType() != Object.class) {
+            if (objectType.getType() != Object.class) {
                 for (Map.Entry<String, DescribableModel<?>> entry :
-                        ((HeterogeneousObjectType) type).getTypes().entrySet()) {
+                        objectType.getTypes().entrySet()) {
                     Set<String> symbols =
                             SymbolLookup.getSymbolValue(entry.getValue().getType());
                     String symbol = symbols.isEmpty()
@@ -99,8 +99,8 @@ public class ToAsciiDoc {
                             .append("</div></li>\n");
                 }
             }
-        } else if (type instanceof ErrorType) { // Shouldn't hit this; open a ticket
-            Exception x = ((ErrorType) type).getError();
+        } else if (type instanceof ErrorType errorType) { // Shouldn't hit this; open a ticket
+            Exception x = errorType.getError();
             LOG.log(Level.FINE, "Encountered ErrorType object with exception:" + x);
             if (x instanceof NoStaplerConstructorException || x instanceof UnsupportedOperationException) {
                 typeInfo.append("<li><b>Type:</b> <code>")
@@ -157,8 +157,8 @@ public class ToAsciiDoc {
                 ParameterType type = param.getType();
                 if (type instanceof AtomicType) {
                     typeDesc = " : " + type;
-                } else if (type instanceof ArrayType) {
-                    type = ((ArrayType) type).getElementType();
+                } else if (type instanceof ArrayType arrayType) {
+                    type = arrayType.getElementType();
                     if (type instanceof AtomicType) {
                         typeDesc = " : " + ARRAY_LIST_OF + type;
                     }

--- a/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
+++ b/src/main/java/org/jenkinsci/pipeline_steps_doc_generator/ToAsciiDoc.java
@@ -232,8 +232,8 @@ public class ToAsciiDoc {
             if (delegateExample.isPresent()) {
                 mkDesc.append(getHelp("help.html", d.real.clazz));
                 String symbol = new QuasiDescriptor(delegateExample.get(), (StepDescriptor) d.real).getSymbol();
-                mkDesc.append(String.format(
-                        "To use this step you need to specify a delegate class, e.g <code>%s</code>.", symbol));
+                mkDesc.append("To use this step you need to specify a delegate class, e.g <code>%s</code>."
+                        .formatted(symbol));
             } else {
                 appendSimpleStepDescription(mkDesc, d.real.clazz);
             }


### PR DESCRIPTION
## Use Java 17 features to simplify the code

Simplify code using pattern matching with instanceof

[OpenJDK JEP 394](https://openjdk.org/jeps/394) describes the feature added in Java 16 (after preview in Java 14 and a second preview in Java 15) that allows an identifier to be defined that is the result of the instanceof operator.

Simplify code with formatted() call on a text block

[OpenJDK JEP 378](https://openjdk.org/jeps/378) describes the addition of text blocks to Java 15.  Text blocks include the addition of the formatted() method to the String class so that a parameterized string can be populated by the call to formatted().

Changes generated with OpenRewrite (thanks for their support of open source software)!