### PR TITLE
Update docs for new allAscii.zip location

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ but uses the AsciiDoc for the `schedule-build-plugin` generated locally.
 
 ```diff
 -  [
--    'https://ci.jenkins.io/job/Infra/job/pipeline-steps-doc-generator/job/master/lastSuccessfulBuild/artifact/allAscii.zip',
+-    'https://reports.jenkins.io/allAscii.zip',
 -    'content/_tmp/allAscii.zip',
 -    nil,
 -    'content/doc/pipeline/steps'
 -  ],
 
-+ # [
-+ #   'https://ci.jenkins.io/job/Infra/job/pipeline-steps-doc-generator/job/master/lastSuccessfulBuild/artifact/allAscii.zip',
-+ #   'content/_tmp/allAscii.zip',
-+ #   nil,
-+ #   'content/doc/pipeline/steps'
-+ # ],
++  # [
++  #   'https://reports.jenkins.io/allAscii.zip',
++  #   'content/_tmp/allAscii.zip',
++  #   nil,
++  #   'content/doc/pipeline/steps'
++  # ],
 ```
 
 ### 4. Create `Makefile`


### PR DESCRIPTION
## Update docs for new allAscii.zip location

The documentation site build process was unnecessarily dependent on ci.jenkins.io.  That was fixed in:

* https://github.com/jenkins-infra/helpdesk/issues/3087

The zip file is now downloaded from reports.jenkins.io.
